### PR TITLE
Fix agent's lock

### DIFF
--- a/app/agent/agent.go
+++ b/app/agent/agent.go
@@ -48,7 +48,7 @@ type Agent struct {
 	caCertPool  *x509.CertPool
 
 	api        *api.Client
-	lock       *sync.Mutex
+	lock       sync.Mutex
 	loopTicker *time.Ticker
 	stop       chan bool
 	update     chan bool


### PR DESCRIPTION
This PR changes the lock on the Agent struct from pointer to a struct, so we don't need to initialize it.