### PR TITLE
Change module path to go.qbee.io/agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.21 as builder
 
 ARG version
-ENV VERSION_VAR=github.com/qbee-io/qbee-agent/app.Version
+ENV VERSION_VAR=go.qbee.io/agent/app.Version
 
 ARG public_signing_key
-ENV PUBLIC_SINGING_KEY_VAR=github.com/qbee-io/qbee-agent/app/binary.PublicSigningKey
+ENV PUBLIC_SINGING_KEY_VAR=go.qbee.io/agent/app/binary.PublicSigningKey
 
 ENV CGO_ENABLED=0
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION=0000.00
-VERSION_VAR=github.com/qbee-io/qbee-agent/app.Version
-COMMIT_VAR=github.com/qbee-io/qbee-agent/app.Commit
+VERSION_VAR=go.qbee.io/agent/app.Version
+COMMIT_VAR=go.qbee.io/agent/app.Commit
 COMMIT=$(shell git describe --always --dirty --abbrev=0)
 GOOS=linux
 GOARCH=amd64
@@ -8,7 +8,7 @@ GOARCH=amd64
 # PUBLIC_SIGNING_KEY is a public part of platform's binary signing key.
 # For production release, it must be replaced with the correct public key.
 PUBLIC_SIGNING_KEY=xSHbUBG7LTuNfXd3zod4EX8_Es8FTCINgrjvx1WXFE4.plCHzlDAeb3IWW1wK6P6paMRYO4f8qceV3lrNCqNpWo
-PUBLIC_SINGING_KEY_VAR=github.com/qbee-io/qbee-agent/app/binary.PublicSigningKey
+PUBLIC_SINGING_KEY_VAR=go.qbee.io/agent/app/binary.PublicSigningKey
 
 build:
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ qbee-agent is the software running on Linux devices which are managed by the [qb
 # License
 
 The qbee-agent is licensed under the Apache License, Version 2.0. See
-[LICENSE](https://github.com/qbee-io/qbee-agent/blob/master/LICENSE) for the full license text.
+[LICENSE](./LICENSE) for the full license text.
 
 # Releasing new version
 

--- a/app/agent/agent.go
+++ b/app/agent/agent.go
@@ -29,13 +29,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/api"
-	"github.com/qbee-io/qbee-agent/app/configuration"
-	"github.com/qbee-io/qbee-agent/app/inventory"
-	"github.com/qbee-io/qbee-agent/app/log"
-	"github.com/qbee-io/qbee-agent/app/metrics"
-	"github.com/qbee-io/qbee-agent/app/remoteaccess"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/configuration"
+	"go.qbee.io/agent/app/inventory"
+	"go.qbee.io/agent/app/log"
+	"go.qbee.io/agent/app/metrics"
+	"go.qbee.io/agent/app/remoteaccess"
+	"go.qbee.io/agent/app/utils"
 )
 
 // Agent is the main agent structure.

--- a/app/agent/api.go
+++ b/app/agent/api.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 	"runtime"
 
-	"github.com/qbee-io/qbee-agent/app"
-	"github.com/qbee-io/qbee-agent/app/binary"
+	"go.qbee.io/agent/app"
+	"go.qbee.io/agent/app/binary"
 )
 
 // BootstrapRequest is the request sent to the device hub during device bootstrap.

--- a/app/agent/bootstrap.go
+++ b/app/agent/bootstrap.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/inventory"
-	"github.com/qbee-io/qbee-agent/app/log"
+	"go.qbee.io/agent/app/inventory"
+	"go.qbee.io/agent/app/log"
 )
 
 const bootstrapWaitTime = 5 * time.Second

--- a/app/agent/credentials.go
+++ b/app/agent/credentials.go
@@ -32,8 +32,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/qbee-io/qbee-agent/app/api"
-	"github.com/qbee-io/qbee-agent/app/log"
+	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/log"
 )
 
 const (

--- a/app/agent/directories.go
+++ b/app/agent/directories.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/qbee-io/qbee-agent/app/configuration"
-	"github.com/qbee-io/qbee-agent/app/log"
+	"go.qbee.io/agent/app/configuration"
+	"go.qbee.io/agent/app/log"
 )
 
 const (

--- a/app/agent/inventory.go
+++ b/app/agent/inventory.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/qbee-io/qbee-agent/app"
-	"github.com/qbee-io/qbee-agent/app/inventory"
+	"go.qbee.io/agent/app"
+	"go.qbee.io/agent/app/inventory"
 )
 
 // doInventories collects all inventories and delivers them to the device hub API.

--- a/app/agent/tpm.go
+++ b/app/agent/tpm.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/go-tpm/tpm2"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/qbee-io/qbee-agent/app/log"
+	"go.qbee.io/agent/app/log"
 )
 
 var tpmPCRSelection = tpm2.PCRSelection{Hash: tpm2.AlgSHA256, PCRs: []int{7}}

--- a/app/agent/updater.go
+++ b/app/agent/updater.go
@@ -23,7 +23,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/qbee-io/qbee-agent/app/binary"
+	"go.qbee.io/agent/app/binary"
 )
 
 // Update the agent binary.

--- a/app/api/client.go
+++ b/app/api/client.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app"
+	"go.qbee.io/agent/app"
 )
 
 // UserAgent is the user agent string used for all API calls.

--- a/app/binary/api.go
+++ b/app/binary/api.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"runtime"
 
-	"github.com/qbee-io/qbee-agent/app/api"
+	"go.qbee.io/agent/app/api"
 )
 
 const downloadPath = "/v1/org/device/auth/download/%s/%s"

--- a/app/binary/download.go
+++ b/app/binary/download.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/qbee-io/qbee-agent/app/api"
+	"go.qbee.io/agent/app/api"
 )
 
 // Binaries supported for automatic distribution and verification.

--- a/app/cmd/bootstrap.go
+++ b/app/cmd/bootstrap.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/qbee-io/qbee-agent/app/agent"
-	"github.com/qbee-io/qbee-agent/app/utils/cmd"
+	"go.qbee.io/agent/app/agent"
+	"go.qbee.io/agent/app/utils/cmd"
 )
 
 const (

--- a/app/cmd/config.go
+++ b/app/cmd/config.go
@@ -22,9 +22,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/qbee-io/qbee-agent/app/agent"
-	"github.com/qbee-io/qbee-agent/app/configuration"
-	"github.com/qbee-io/qbee-agent/app/utils/cmd"
+	"go.qbee.io/agent/app/agent"
+	"go.qbee.io/agent/app/configuration"
+	"go.qbee.io/agent/app/utils/cmd"
 )
 
 const (

--- a/app/cmd/inventory.go
+++ b/app/cmd/inventory.go
@@ -22,9 +22,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/qbee-io/qbee-agent/app/agent"
-	"github.com/qbee-io/qbee-agent/app/inventory"
-	"github.com/qbee-io/qbee-agent/app/utils/cmd"
+	"go.qbee.io/agent/app/agent"
+	"go.qbee.io/agent/app/inventory"
+	"go.qbee.io/agent/app/utils/cmd"
 )
 
 const (

--- a/app/cmd/main.go
+++ b/app/cmd/main.go
@@ -17,9 +17,9 @@
 package cmd
 
 import (
-	"github.com/qbee-io/qbee-agent/app/agent"
-	"github.com/qbee-io/qbee-agent/app/log"
-	"github.com/qbee-io/qbee-agent/app/utils/cmd"
+	"go.qbee.io/agent/app/agent"
+	"go.qbee.io/agent/app/log"
+	"go.qbee.io/agent/app/utils/cmd"
 )
 
 const (

--- a/app/cmd/start.go
+++ b/app/cmd/start.go
@@ -19,9 +19,9 @@ package cmd
 import (
 	"context"
 
-	"github.com/qbee-io/qbee-agent/app/agent"
-	"github.com/qbee-io/qbee-agent/app/log"
-	"github.com/qbee-io/qbee-agent/app/utils/cmd"
+	"go.qbee.io/agent/app/agent"
+	"go.qbee.io/agent/app/log"
+	"go.qbee.io/agent/app/utils/cmd"
 )
 
 const (

--- a/app/cmd/update.go
+++ b/app/cmd/update.go
@@ -19,8 +19,8 @@ package cmd
 import (
 	"context"
 
-	"github.com/qbee-io/qbee-agent/app/agent"
-	"github.com/qbee-io/qbee-agent/app/utils/cmd"
+	"go.qbee.io/agent/app/agent"
+	"go.qbee.io/agent/app/utils/cmd"
 )
 
 var updateCommand = cmd.Command{

--- a/app/cmd/version.go
+++ b/app/cmd/version.go
@@ -19,8 +19,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/qbee-io/qbee-agent/app"
-	"github.com/qbee-io/qbee-agent/app/utils/cmd"
+	"go.qbee.io/agent/app"
+	"go.qbee.io/agent/app/utils/cmd"
 )
 
 var versionCommand = cmd.Command{

--- a/app/configuration/api.go
+++ b/app/configuration/api.go
@@ -24,7 +24,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/qbee-io/qbee-agent/app/log"
+	"go.qbee.io/agent/app/log"
 )
 
 const deviceConfigurationAPIPath = "/v1/org/device/auth/config"

--- a/app/configuration/bundle_connectivity_watchdog_test.go
+++ b/app/configuration/bundle_connectivity_watchdog_test.go
@@ -21,8 +21,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/api"
-	"github.com/qbee-io/qbee-agent/app/configuration"
+	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/configuration"
 )
 
 func Test_ConnectivityWatchdog(t *testing.T) {

--- a/app/configuration/bundle_docker_containers.go
+++ b/app/configuration/bundle_docker_containers.go
@@ -30,7 +30,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // DockerContainersBundle controls docker containers running in the system.

--- a/app/configuration/bundle_docker_containers_test.go
+++ b/app/configuration/bundle_docker_containers_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/configuration"
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
-	"github.com/qbee-io/qbee-agent/app/utils/runner"
+	"go.qbee.io/agent/app/configuration"
+	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/runner"
 )
 
 func Test_DockerContainers_Auths(t *testing.T) {

--- a/app/configuration/bundle_docker_containers_test.go
+++ b/app/configuration/bundle_docker_containers_test.go
@@ -19,6 +19,7 @@ package configuration_test
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -28,6 +29,10 @@ import (
 )
 
 func Test_DockerContainers_Auths(t *testing.T) {
+	if os.Getenv("DOCKER_USERNAME") == "" || os.Getenv("DOCKER_PASSWORD") == "" {
+		t.Skip("Skipping test, since DOCKER_USERNAME and DOCKER_PASSWORD are not set")
+	}
+
 	r := runner.New(t)
 
 	r.MustExec("apt-get", "install", "-y", "docker-ce-cli")
@@ -35,8 +40,8 @@ func Test_DockerContainers_Auths(t *testing.T) {
 	dockerBundle := configuration.DockerContainersBundle{
 		RegistryAuths: []configuration.RegistryAuth{
 			{
-				Username: "qbeetester",
-				Password: "dckr_pat_rGiJ1QOxQNeVeJHbonJyXfKaZsY",
+				Username: os.Getenv("DOCKER_USERNAME"),
+				Password: os.Getenv("DOCKER_PASSWORD"),
 			},
 		},
 	}

--- a/app/configuration/bundle_file_distribution_test.go
+++ b/app/configuration/bundle_file_distribution_test.go
@@ -21,9 +21,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/configuration"
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
-	"github.com/qbee-io/qbee-agent/app/utils/runner"
+	"go.qbee.io/agent/app/configuration"
+	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/runner"
 )
 
 func Test_FileDistributionBundle(t *testing.T) {

--- a/app/configuration/bundle_firewall.go
+++ b/app/configuration/bundle_firewall.go
@@ -23,8 +23,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/remoteaccess"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/remoteaccess"
+	"go.qbee.io/agent/app/utils"
 )
 
 // FirewallBundle configures system firewall.

--- a/app/configuration/bundle_firewall_test.go
+++ b/app/configuration/bundle_firewall_test.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/configuration"
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
-	"github.com/qbee-io/qbee-agent/app/utils/runner"
+	"go.qbee.io/agent/app/configuration"
+	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/runner"
 )
 
 func Test_Firewall_NoIPTablesInstalled(t *testing.T) {

--- a/app/configuration/bundle_package_management.go
+++ b/app/configuration/bundle_package_management.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/qbee-io/qbee-agent/app/software"
+	"go.qbee.io/agent/app/software"
 )
 
 // PackageManagementBundle controls system packages.

--- a/app/configuration/bundle_package_management_test.go
+++ b/app/configuration/bundle_package_management_test.go
@@ -20,9 +20,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/configuration"
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
-	"github.com/qbee-io/qbee-agent/app/utils/runner"
+	"go.qbee.io/agent/app/configuration"
+	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/runner"
 )
 
 func Test_PackageManagement_PreCondition(t *testing.T) {

--- a/app/configuration/bundle_parameters_test.go
+++ b/app/configuration/bundle_parameters_test.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
-	"github.com/qbee-io/qbee-agent/app/utils/runner"
+	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/runner"
 )
 
 func Test_resolveParameters(t *testing.T) {

--- a/app/configuration/bundle_password.go
+++ b/app/configuration/bundle_password.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/inventory"
+	"go.qbee.io/agent/app/inventory"
 )
 
 // PasswordBundle bundle sets passwords for existing users.

--- a/app/configuration/bundle_password_test.go
+++ b/app/configuration/bundle_password_test.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/configuration"
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
-	"github.com/qbee-io/qbee-agent/app/utils/runner"
+	"go.qbee.io/agent/app/configuration"
+	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/runner"
 )
 
 func Test_Password(t *testing.T) {

--- a/app/configuration/bundle_process_watch.go
+++ b/app/configuration/bundle_process_watch.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/inventory/linux"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/utils"
 )
 
 // ProcessWatchBundle ensures running process are running (or not).

--- a/app/configuration/bundle_process_watch_test.go
+++ b/app/configuration/bundle_process_watch_test.go
@@ -132,12 +132,8 @@ func Test_BundleProcessWatch_CommandError(t *testing.T) {
 
 	assert.Equal(t, reports, expectedReports)
 
-	expectedLogs := []string{
-		"error running command [/bin/bash -c invalidCommand]: exit status 127",
-		"/bin/bash: line 1: invalidCommand: command not found",
-	}
-
-	assert.Equal(t, logs, expectedLogs)
+	assert.MatchString(t, logs[0], "error running command \\[.* -c invalidCommand\\]: exit status 127")
+	assert.MatchString(t, logs[1], ".* line 1: invalidCommand: command not found")
 }
 
 // executePackageManagementBundle is a helper method to quickly execute process watch bundle.

--- a/app/configuration/bundle_process_watch_test.go
+++ b/app/configuration/bundle_process_watch_test.go
@@ -19,9 +19,9 @@ package configuration_test
 import (
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/configuration"
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
-	"github.com/qbee-io/qbee-agent/app/utils/runner"
+	"go.qbee.io/agent/app/configuration"
+	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/runner"
 )
 
 func Test_BundleProcessWatch_ProcessPresent_NotRunning(t *testing.T) {
@@ -133,8 +133,8 @@ func Test_BundleProcessWatch_CommandError(t *testing.T) {
 	assert.Equal(t, reports, expectedReports)
 
 	expectedLogs := []string{
-		"error running command [/usr/bin/bash -c invalidCommand]: exit status 127",
-		"/usr/bin/bash: line 1: invalidCommand: command not found",
+		"error running command [/bin/bash -c invalidCommand]: exit status 127",
+		"/bin/bash: line 1: invalidCommand: command not found",
 	}
 
 	assert.Equal(t, logs, expectedLogs)

--- a/app/configuration/bundle_software_management.go
+++ b/app/configuration/bundle_software_management.go
@@ -24,8 +24,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/software"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/software"
+	"go.qbee.io/agent/app/utils"
 )
 
 // SoftwareManagementBundle controls software in the system.

--- a/app/configuration/bundle_software_management_test.go
+++ b/app/configuration/bundle_software_management_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/configuration"
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
-	"github.com/qbee-io/qbee-agent/app/utils/runner"
+	"go.qbee.io/agent/app/configuration"
+	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/runner"
 )
 
 const cacheDir = "/var/lib/qbee/app_workdir/cache"

--- a/app/configuration/bundle_sshkeys.go
+++ b/app/configuration/bundle_sshkeys.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/inventory"
+	"go.qbee.io/agent/app/inventory"
 )
 
 // SSHKeysBundle adds or removes authorized SSH keys for users.

--- a/app/configuration/bundle_users.go
+++ b/app/configuration/bundle_users.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/qbee-io/qbee-agent/app/inventory"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/inventory"
+	"go.qbee.io/agent/app/utils"
 )
 
 // UsersBundle adds or removes users.

--- a/app/configuration/command_linux.go
+++ b/app/configuration/command_linux.go
@@ -25,7 +25,7 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 var supportedShells = []string{"bash", "zsh", "sh"}

--- a/app/configuration/export_test.go
+++ b/app/configuration/export_test.go
@@ -19,7 +19,7 @@ package configuration
 import (
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/utils/runner"
+	"go.qbee.io/agent/app/utils/runner"
 )
 
 // ResetRebootAfterRun allows to reset internal rebootAfterRun flag from tests.

--- a/app/configuration/pre_conditions.go
+++ b/app/configuration/pre_conditions.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // CheckPreCondition checks if the provided pre-condition is met.

--- a/app/configuration/report_test.go
+++ b/app/configuration/report_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func Test_Reporter_Redact(t *testing.T) {

--- a/app/configuration/service.go
+++ b/app/configuration/service.go
@@ -26,8 +26,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/api"
-	"github.com/qbee-io/qbee-agent/app/log"
+	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/log"
 )
 
 const defaultAgentInterval = 5 // minutes

--- a/app/configuration/service_test.go
+++ b/app/configuration/service_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/api"
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
+	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func TestService_reportsBuffer(t *testing.T) {

--- a/app/inventory/docker_containers.go
+++ b/app/inventory/docker_containers.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // TypeDockerContainers is the inventory type for Docker containers.

--- a/app/inventory/docker_images.go
+++ b/app/inventory/docker_images.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // TypeDockerImages is the inventory type for Docker images.

--- a/app/inventory/docker_networks.go
+++ b/app/inventory/docker_networks.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // TypeDockerNetworks is the inventory type for Docker networks.

--- a/app/inventory/docker_volumes.go
+++ b/app/inventory/docker_volumes.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // TypeDockerVolumes is the inventory type for Docker volumes.

--- a/app/inventory/linux/mem_info.go
+++ b/app/inventory/linux/mem_info.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // MemInfo provides basic information about system memory.

--- a/app/inventory/linux/process_status.go
+++ b/app/inventory/linux/process_status.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // ProcessStatus contains information about a process.

--- a/app/inventory/linux/running_processes.go
+++ b/app/inventory/linux/running_processes.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // ListRunningProcesses returns a list of PIDs of currently running processes.

--- a/app/inventory/ports_linux.go
+++ b/app/inventory/ports_linux.go
@@ -30,9 +30,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/qbee-io/qbee-agent/app/inventory/linux"
-	"github.com/qbee-io/qbee-agent/app/log"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/log"
+	"go.qbee.io/agent/app/utils"
 )
 
 // CollectPortsInventory returns populated Ports inventory based on current system status.

--- a/app/inventory/processes_linux.go
+++ b/app/inventory/processes_linux.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/inventory/linux"
+	"go.qbee.io/agent/app/inventory/linux"
 )
 
 // CollectProcessesInventory returns populated Processes inventory based on current system status.

--- a/app/inventory/processes_linux_test.go
+++ b/app/inventory/processes_linux_test.go
@@ -18,7 +18,7 @@ package inventory
 import (
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func TestCollectProcessesInventory(t *testing.T) {

--- a/app/inventory/service.go
+++ b/app/inventory/service.go
@@ -24,8 +24,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/qbee-io/qbee-agent/app/api"
-	"github.com/qbee-io/qbee-agent/app/log"
+	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/log"
 )
 
 // Service provides methods for collecting and delivering inventory data.

--- a/app/inventory/software.go
+++ b/app/inventory/software.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/qbee-io/qbee-agent/app/log"
-	"github.com/qbee-io/qbee-agent/app/software"
+	"go.qbee.io/agent/app/log"
+	"go.qbee.io/agent/app/software"
 )
 
 // TypeSoftware is the inventory type for software information.

--- a/app/inventory/software_test.go
+++ b/app/inventory/software_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/utils/runner"
+	"go.qbee.io/agent/app/utils/runner"
 )
 
 func TestCollectSoftwareInventory_Deb(t *testing.T) {

--- a/app/inventory/system_linux.go
+++ b/app/inventory/system_linux.go
@@ -28,10 +28,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app"
-	"github.com/qbee-io/qbee-agent/app/inventory/linux"
-	"github.com/qbee-io/qbee-agent/app/log"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app"
+	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/log"
+	"go.qbee.io/agent/app/utils"
 )
 
 const (

--- a/app/inventory/system_linux_test.go
+++ b/app/inventory/system_linux_test.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/inventory"
+	"go.qbee.io/agent/app/inventory"
 )
 
 func TestCollectSystemInventory(t *testing.T) {

--- a/app/inventory/users_linux.go
+++ b/app/inventory/users_linux.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // Paths to standard passwd and shadow files.

--- a/app/inventory/users_linux_test.go
+++ b/app/inventory/users_linux_test.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/qbee-io/qbee-agent/app/inventory"
+	"go.qbee.io/agent/app/inventory"
 )
 
 func TestCollectUsersInventory(t *testing.T) {

--- a/app/metrics/cpu.go
+++ b/app/metrics/cpu.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/qbee-io/qbee-agent/app/inventory/linux"
+	"go.qbee.io/agent/app/inventory/linux"
 )
 
 // CPUValues contains CPU metrics.

--- a/app/metrics/filesystem.go
+++ b/app/metrics/filesystem.go
@@ -22,8 +22,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/inventory/linux"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/utils"
 )
 
 // FilesystemValues represents filesystem metric values.

--- a/app/metrics/filesystem_test.go
+++ b/app/metrics/filesystem_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func TestCollectFilesystem(t *testing.T) {

--- a/app/metrics/loadavg.go
+++ b/app/metrics/loadavg.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/inventory/linux"
+	"go.qbee.io/agent/app/inventory/linux"
 )
 
 // LoadAverageValues contains load average metrics.

--- a/app/metrics/loadavg_test.go
+++ b/app/metrics/loadavg_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func TestCollectLoadAverage(t *testing.T) {

--- a/app/metrics/memory.go
+++ b/app/metrics/memory.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/inventory/linux"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/utils"
 )
 
 // MemoryValues contains memory metrics.

--- a/app/metrics/memory_test.go
+++ b/app/metrics/memory_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func TestCollectMemory(t *testing.T) {

--- a/app/metrics/network.go
+++ b/app/metrics/network.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/inventory/linux"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/utils"
 )
 
 // NetworkValues contains network metrics for an interface.

--- a/app/metrics/network_test.go
+++ b/app/metrics/network_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func TestCollectNetwork(t *testing.T) {

--- a/app/metrics/service.go
+++ b/app/metrics/service.go
@@ -20,8 +20,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/api"
-	"github.com/qbee-io/qbee-agent/app/log"
+	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/log"
 )
 
 // Service collects system metrics and sends them to the device hub.

--- a/app/metrics/service_test.go
+++ b/app/metrics/service_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/api"
+	"go.qbee.io/agent/app/api"
 )
 
 func TestCollectServiceCollectAll(t *testing.T) {

--- a/app/remoteaccess/service.go
+++ b/app/remoteaccess/service.go
@@ -27,10 +27,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/api"
-	"github.com/qbee-io/qbee-agent/app/binary"
-	"github.com/qbee-io/qbee-agent/app/log"
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/binary"
+	"go.qbee.io/agent/app/log"
+	"go.qbee.io/agent/app/utils"
 )
 
 // NetworkInterfaceName is the name of the network interface used for remote access.

--- a/app/remoteaccess/service_test.go
+++ b/app/remoteaccess/service_test.go
@@ -29,8 +29,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/qbee-io/qbee-agent/app/api"
-	"github.com/qbee-io/qbee-agent/app/utils/assert"
+	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func TestService_downloadOpenVPN(t *testing.T) {

--- a/app/software/package_manager_deb.go
+++ b/app/software/package_manager_deb.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/qbee-io/qbee-agent/app/utils"
+	"go.qbee.io/agent/app/utils"
 )
 
 // PackageManagerTypeDebian is the type of the Debian package manager.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/qbee-io/qbee-agent
+module go.qbee.io/agent
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/qbee-io/qbee-agent/app/cmd"
+	"go.qbee.io/agent/app/cmd"
 )
 
 var defaultUmask int = 0077


### PR DESCRIPTION
This PR updates the module path to the new vanity one: go.qbee.io/agent

Additionally - after being flagged by GitHub - this PR removes the hard coded Docker hub credentials (which are already invalidated).