### PR TITLE
DEV-2082: Don't send unused metrics

### DIFF
--- a/app/metrics/cpu.go
+++ b/app/metrics/cpu.go
@@ -34,19 +34,16 @@ import (
 //
 //	{
 //	 "user": 2.08,
-//	 "nice": 0.00,
 //	 "system": 0.76,
-//	 "idle": 97.16,
 //	 "iowait": 0.00,
-//	 "irq": 0.00
 //	}
 type CPUValues struct {
 	User   float64 `json:"user"`
-	Nice   float64 `json:"nice"`
+	Nice   float64 `json:"-"`
 	System float64 `json:"system"`
-	Idle   float64 `json:"idle"`
+	Idle   float64 `json:"-"`
 	IOWait float64 `json:"iowait"`
-	IRQ    float64 `json:"irq"`
+	IRQ    float64 `json:"-"`
 }
 
 // CollectCPU returns CPU metrics.

--- a/app/metrics/filesystem.go
+++ b/app/metrics/filesystem.go
@@ -31,24 +31,12 @@ import (
 // Example payload:
 //
 //	{
-//	 "size": 486903968,
-//	 "used": 62249152,
 //	 "avail": 399848008,
 //	 "use": 14,
-//	 "inodes": 30990336,
-//	 "iused": 844508,
-//	 "ifree": 30145828,
-//	 "iuse": 3
 //	}
 type FilesystemValues struct {
-	Size      uint64 `json:"size"`
-	Used      uint64 `json:"used"`
 	Available uint64 `json:"avail"`
 	Use       uint64 `json:"use"`
-	INodes    uint64 `json:"inodes"`
-	IUsed     uint64 `json:"iused"`
-	IFree     uint64 `json:"ifree"`
-	IUse      uint64 `json:"iuse"`
 }
 
 const fsBlockSize = 1024
@@ -69,17 +57,13 @@ func CollectFilesystem() ([]Metric, error) {
 			return nil, err
 		}
 
-		size := uint64(st.Blocks) * uint64(st.Bsize) / fsBlockSize
-		free := uint64(st.Bavail) * uint64(st.Bsize) / fsBlockSize
+		size := st.Blocks * uint64(st.Bsize) / fsBlockSize
+		free := st.Bavail * uint64(st.Bsize) / fsBlockSize
 
-		var iuse, use uint64
+		var use uint64
 
 		if size > 0 {
 			use = 100 - (100*free)/size
-		}
-
-		if st.Files > 0 {
-			iuse = 100 - uint64(st.Ffree*100/st.Files)
 		}
 
 		metrics[i] = Metric{
@@ -88,14 +72,8 @@ func CollectFilesystem() ([]Metric, error) {
 			ID:        mount,
 			Values: Values{
 				FilesystemValues: &FilesystemValues{
-					Size:      size,
-					Used:      size - free,
 					Available: free,
 					Use:       use,
-					INodes:    uint64(st.Files),
-					IUsed:     uint64(st.Files - st.Ffree),
-					IFree:     uint64(st.Ffree),
-					IUse:      iuse,
 				},
 			},
 		}

--- a/app/metrics/memory.go
+++ b/app/metrics/memory.go
@@ -31,23 +31,18 @@ import (
 // Example payload:
 //
 //	{
-//	 "memtot": 32521216,
-//	 "memused": 5729248,
 //	 "memfree": 26791968,
 //	 "memutil": 17,
-//	 "swaptot": 2002940,
-//	 "swapused": 0,
-//	 "swapfree": 2002940,
 //	 "swaputil": 0
 //	}
 type MemoryValues struct {
-	MemoryTotal       int `json:"memtot"`
-	MemoryUsed        int `json:"memused"`
+	MemoryTotal       int `json:"-"`
+	MemoryUsed        int `json:"-"`
 	MemoryFree        int `json:"memfree"`
 	MemoryUtilization int `json:"memutil"`
-	SwapTotal         int `json:"swaptot"`
-	SwapUsed          int `json:"swapused"`
-	SwapFree          int `json:"swapfree"`
+	SwapTotal         int `json:"-"`
+	SwapUsed          int `json:"-"`
+	SwapFree          int `json:"-"`
 	SwapUtilization   int `json:"swaputil"`
 }
 


### PR DESCRIPTION
Not all collected metrics are used by qbee, so there is not point in sending those to the Device Hub.
This PR removes unused fields from the payload.