### PR TITLE
DEV-2462: Use file digest provided by the file distribution to avoid unnecessary file metadata requests

### DIFF
--- a/app/configuration/bundle_docker_compose.go
+++ b/app/configuration/bundle_docker_compose.go
@@ -226,9 +226,9 @@ func (c Compose) getComposeFile(ctx context.Context, service *Service) (bool, er
 	parameters := templateParametersMap(c.Parameters)
 
 	if len(parameters) > 0 {
-		return service.downloadTemplateFile(ctx, "", c.File, composeFilePath, parameters)
+		return service.downloadTemplateFile(ctx, "", c.File, composeFilePath, "", parameters)
 	}
-	return service.downloadFile(ctx, "", c.File, composeFilePath)
+	return service.downloadFile(ctx, "", c.File, composeFilePath, "")
 }
 
 func (c Compose) getProjectDirectory(service *Service) string {

--- a/app/configuration/bundle_file_distribution.go
+++ b/app/configuration/bundle_file_distribution.go
@@ -75,6 +75,9 @@ type File struct {
 	// Source full file path from the file manager.
 	Source string `json:"source"`
 
+	// Digest (SHA256) of the source file.
+	Digest string `json:"digest"`
+
 	// Destination defines absolute path of the file in the filesystem.
 	Destination string `json:"destination"`
 
@@ -108,9 +111,9 @@ func (fd FileDistributionBundle) Execute(ctx context.Context, service *Service) 
 			var created bool
 
 			if file.IsTemplate {
-				created, err = service.downloadTemplateFile(ctx, fileSet.Label, fileSource, fileDestination, parameters)
+				created, err = service.downloadTemplateFile(ctx, fileSet.Label, fileSource, fileDestination, file.Digest, parameters)
 			} else {
-				created, err = service.downloadFile(ctx, fileSet.Label, fileSource, fileDestination)
+				created, err = service.downloadFile(ctx, fileSet.Label, fileSource, fileDestination, file.Digest)
 			}
 
 			if err != nil {

--- a/app/configuration/bundle_software_management.go
+++ b/app/configuration/bundle_software_management.go
@@ -156,7 +156,7 @@ func (s Software) Execute(ctx context.Context, srv *Service, pkgManager software
 		var created bool
 
 		parameters := templateParametersMap(s.Parameters)
-		created, err = srv.downloadTemplateFile(ctx, "", cfgFile.ConfigTemplate, cfgFile.ConfigLocation, parameters)
+		created, err = srv.downloadTemplateFile(ctx, "", cfgFile.ConfigTemplate, cfgFile.ConfigLocation, "", parameters)
 		if err != nil {
 			return err
 		}
@@ -184,7 +184,7 @@ func (s Software) installFromFile(ctx context.Context, srv *Service, pkgManager 
 	} else {
 		pkgFileCachePath = filepath.Join(srv.cacheDirectory, SoftwareCacheDirectory, s.Package)
 
-		if _, err := srv.downloadFile(ctx, "", s.Package, pkgFileCachePath); err != nil {
+		if _, err := srv.downloadFile(ctx, "", s.Package, pkgFileCachePath, ""); err != nil {
 			return false, err
 		}
 	}

--- a/app/configuration/containers.go
+++ b/app/configuration/containers.go
@@ -76,7 +76,7 @@ func (c Container) execute(ctx context.Context, srv *Service, containerBin strin
 
 	envFilePath := c.localEnvFilePath(srv)
 	if envFilePath != "" {
-		if needRestart, err = srv.downloadFile(ctx, "", c.EnvFile, envFilePath); err != nil {
+		if needRestart, err = srv.downloadFile(ctx, "", c.EnvFile, envFilePath, ""); err != nil {
 			return err
 		}
 	}

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -93,7 +93,7 @@ func (md *FileMetadata) SHA256() string {
 }
 
 // downloadFile and return true when file was created. In case the right file already existed, return false.
-func (srv *Service) downloadFile(ctx context.Context, label, src, dst string) (bool, error) {
+func (srv *Service) downloadFile(ctx context.Context, label, src, dst, digest string) (bool, error) {
 	var err error
 
 	src = resolveParameters(ctx, src)
@@ -111,7 +111,13 @@ func (srv *Service) downloadFile(ctx context.Context, label, src, dst string) (b
 	}
 
 	var fileMetadata *FileMetadata
-	if fileMetadata, err = srv.getFileMetadata(ctx, src); err != nil {
+	if digest != "" {
+		fileMetadata = &FileMetadata{
+			Tags: map[string]string{
+				fileDigestSHA256Tag: digest,
+			},
+		}
+	} else if fileMetadata, err = srv.getFileMetadata(ctx, src); err != nil {
 		return false, err
 	}
 
@@ -213,6 +219,7 @@ func (srv *Service) downloadTemplateFile(
 	label string,
 	src string,
 	dst string,
+	digest string,
 	params map[string]string,
 ) (bool, error) {
 	var err error
@@ -237,7 +244,7 @@ func (srv *Service) downloadTemplateFile(
 	} else {
 		cacheSrc = filepath.Join(srv.cacheDirectory, FileDistributionCacheDirectory, src)
 
-		if _, err = srv.downloadFile(ctx, label, src, cacheSrc); err != nil {
+		if _, err = srv.downloadFile(ctx, label, src, cacheSrc, digest); err != nil {
 			return false, err
 		}
 	}


### PR DESCRIPTION
This PR introduces support for the optional file digest (SHA256) provided with the agent config. This change intends to reduce the amount of file metadata requests when files don't use dynamic paths.

### File Integrity Verification Enhancements:
* `app/configuration/file_manager.go`:
  - Modified the `downloadFile` method to include a `digest` parameter and added logic to use the provided digest for file integrity verification. [[1]](diffhunk://#diff-90619c7cfbaac6a8f8267fa41ad6d29dd5100c7528f4828f88ddc948311c5326L96-R96) [[2]](diffhunk://#diff-90619c7cfbaac6a8f8267fa41ad6d29dd5100c7528f4828f88ddc948311c5326L114-R120)
  - Updated the `downloadTemplateFile` method to include a `digest` parameter and pass it to the `downloadFile` method. [[1]](diffhunk://#diff-90619c7cfbaac6a8f8267fa41ad6d29dd5100c7528f4828f88ddc948311c5326R222) [[2]](diffhunk://#diff-90619c7cfbaac6a8f8267fa41ad6d29dd5100c7528f4828f88ddc948311c5326L240-R247)

* `app/configuration/bundle_file_distribution.go`:
  - Added a `Digest` field to the `File` struct to store the SHA256 digest of source files.
  - Updated the `Execute` method to pass the `Digest` field to `downloadFile` and `downloadTemplateFile` calls.

### Updates to Existing Call Sites:
* `app/configuration/bundle_docker_compose.go`:
  - Updated `getComposeFile` to pass an empty string as the `digest` parameter to `downloadFile` and `downloadTemplateFile`.
* `app/configuration/bundle_software_management.go`:
  - Updated `Execute` and `installFromFile` methods to include the `digest` parameter in file download calls. [[1]](diffhunk://#diff-40c000090bc151254df0f006cc7bdce76e55df8e5ba76d1684fae78dd4008e3bL159-R159) [[2]](diffhunk://#diff-40c000090bc151254df0f006cc7bdce76e55df8e5ba76d1684fae78dd4008e3bL187-R187)
* `app/configuration/containers.go`:
  - Updated the `execute` method to include the `digest` parameter in `downloadFile` calls.