### PR TITLE
DEV-2536: Use the device settings when running config command line tool.

### DIFF
--- a/app/cmd/config.go
+++ b/app/cmd/config.go
@@ -78,10 +78,6 @@ var configCommand = cmd.Command{
 			return fmt.Errorf("error initializing the agent: %w", err)
 		}
 
-		if reportToConsole {
-			deviceAgent.Configuration.EnableConsoleReporting()
-		}
-
 		if err != nil {
 			return fmt.Errorf("error initializing the agent: %w", err)
 		}
@@ -110,6 +106,10 @@ var configCommand = cmd.Command{
 		}
 
 		deviceAgent.Configuration.UpdateSettings(configurationData)
+
+		if reportToConsole {
+			deviceAgent.Configuration.EnableConsoleReporting()
+		}
 
 		return deviceAgent.Configuration.Execute(ctx, configurationData)
 	},

--- a/app/cmd/config.go
+++ b/app/cmd/config.go
@@ -109,6 +109,8 @@ var configCommand = cmd.Command{
 			return json.NewEncoder(os.Stdout).Encode(configurationData)
 		}
 
+		deviceAgent.Configuration.UpdateSettings(configurationData)
+
 		return deviceAgent.Configuration.Execute(ctx, configurationData)
 	},
 }

--- a/app/configuration/bundle_metrics_monitor_test.go
+++ b/app/configuration/bundle_metrics_monitor_test.go
@@ -177,8 +177,12 @@ func Test_Monitor_State_Delete(t *testing.T) {
 
 func executeMetricMonitorBundle(r *runner.Runner, bundle configuration.MetricsMonitorBundle) []string {
 	config := configuration.CommittedConfig{
-		Bundles: []string{configuration.BundleMetricsMonitor},
+		Bundles: []string{configuration.BundleMetricsMonitor, configuration.BundleSettings},
 		BundleData: configuration.BundleData{
+			Settings: configuration.SettingsBundle{
+				Metadata:      configuration.Metadata{Enabled: true},
+				EnableReports: false,
+			},
 			MetricsMonitor: &bundle,
 		},
 	}

--- a/app/configuration/config.go
+++ b/app/configuration/config.go
@@ -16,6 +16,8 @@
 
 package configuration
 
+import "slices"
+
 // Supported configuration bundles.
 const (
 	BundleSettings             = "settings"
@@ -54,13 +56,7 @@ type CommittedConfig struct {
 
 // HasBundle returns true if bundleName is set in the Bundles list.
 func (cc *CommittedConfig) HasBundle(bundleName string) bool {
-	for _, bundle := range cc.Bundles {
-		if bundle == bundleName {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(cc.Bundles, bundleName)
 }
 
 // selectBundleByName returns Bundle by name from the CommittedConfig.

--- a/app/configuration/service.go
+++ b/app/configuration/service.go
@@ -150,7 +150,6 @@ func (srv *Service) EnableConsoleReporting() {
 
 // applyDefaultSettings to the agent.
 func (srv *Service) applyDefaultSettings() {
-	srv.reportToConsole = true
 	srv.reportingEnabled = true
 	srv.metricsEnabled = true
 	srv.softwareInventoryEnabled = true

--- a/app/metrics/filesystem_test.go
+++ b/app/metrics/filesystem_test.go
@@ -41,7 +41,7 @@ func TestCollectFilesystem(t *testing.T) {
 			t.Fatalf("expected filesystem mount to be under root, got %s", metric.ID)
 		}
 
-		if time.Since(time.Unix(metric.Timestamp, 0)) > time.Second {
+		if time.Since(time.Unix(metric.Timestamp, 0)) > 5*time.Second {
 			t.Fatalf("invalid timestamp, got: %v", metric.Timestamp)
 		}
 	}


### PR DESCRIPTION
This pull request includes a small change to the `configCommand` in `app/cmd/config.go`. The change ensures that the `UpdateSettings` method is called on `deviceAgent.Configuration` before executing the configuration, which updates internal settings with the provided `configurationData`.

Without this, the reporting subsystem won't work as the qbee-agent reports:

```
reporting is disabled - skipping sending reports
```