### PR TITLE
Fix release process

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,8 +14,8 @@ builds:
     ldflags:
       - -s 
       - -w 
-      - -X github.com/qbee-io/qbee-agent-release-test/app.Version={{.Version}}
-      - -X github.com/qbee-io/qbee-agent-release-test/app.Commit={{.FullCommit}}
+      - -X go.qbee.io/agent/app.Version={{.Version}}
+      - -X go.qbee.io/agent/app.Commit={{.FullCommit}}
 
     goos:
       - linux


### PR DESCRIPTION
This pull request updates the linker flags in the `.goreleaser.yaml` configuration to use the new Go module path for setting version and commit information.

Build configuration update:

* Changed the linker flags in `.goreleaser.yaml` to reference `go.qbee.io/agent/app.Version` and `go.qbee.io/agent/app.Commit` instead of the old `github.com/qbee-io/qbee-agent-release-test` path.