### PR TITLE
DEV-2573: Fix tests for debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,14 +26,26 @@ COPY test/resources/debian /apt-repo
 RUN echo "deb [trusted=yes] file:/apt-repo/repo ./" > /etc/apt/sources.list.d/qbee-dev.list
 
 # Install ca-certificates in latest version
-RUN apt-get update && apt-get install -y ca-certificates curl
+RUN apt-get update && \
+  apt-get install -y ca-certificates curl && \
+  install -m 0755 -d /etc/apt/keyrings && \
+  curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+  chmod a+r /etc/apt/keyrings/docker.asc
 
 # add docker repo, so we can install it when needed (disable auth)
 RUN echo 'Acquire::https { Verify-Peer "false" }' > /etc/apt/apt.conf.d/99verify-peer.conf
-RUN echo "deb [trusted=yes] http://download.docker.com/linux/debian bullseye stable" \
+RUN echo "deb [trusted=yes] http://download.docker.com/linux/debian bookworm stable" \
     > /etc/apt/sources.list.d/docker.list
 
+# Add Docker's official GPG key:
+
+# Add the repository to Apt sources:
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
 # update apt cache
+#RUN apt-get --allow-releaseinfo-change update && apt-get upgrade -y
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install docker-ce-cli podman -y 
 

--- a/app/configuration/bundle_podman_containers_test.go
+++ b/app/configuration/bundle_podman_containers_test.go
@@ -38,7 +38,7 @@ func Test_PodmanContainers_Container_Start(t *testing.T) {
 			{
 				Name:    containerName,
 				Image:   "alpine:latest",
-				Args:    "--rm",
+				Args:    "--rm --cgroups=disabled",
 				Command: "sleep 5",
 			},
 		},
@@ -74,7 +74,7 @@ func Test_PodmanContainers_Container_Change(t *testing.T) {
 			{
 				Name:    containerName,
 				Image:   "alpine:latest",
-				Args:    "--rm",
+				Args:    "--rm --cgroups=disabled",
 				Command: "sleep 5",
 			},
 		},
@@ -88,7 +88,7 @@ func Test_PodmanContainers_Container_Change(t *testing.T) {
 
 	assert.Equal(t, reports, expectedReports)
 
-	podmanBundle.Containers[0].Args = "--rm -p 8080:80"
+	podmanBundle.Containers[0].Args = fmt.Sprintf("%s -p 8080:80", podmanBundle.Containers[0].Args)
 
 	expectedReports = []string{
 		"[WARN] Container configuration update detected for image alpine:latest.",
@@ -111,6 +111,7 @@ func Test_PodmanContainers_Container_StartExited(t *testing.T) {
 			{
 				Name:    containerName,
 				Image:   "alpine:latest",
+				Args:    "--cgroups=disabled",
 				Command: "echo 1",
 			},
 		},
@@ -131,7 +132,7 @@ func Test_PodmanContainers_Container_StartExited(t *testing.T) {
 			{
 				Name:    containerName,
 				Image:   "alpine:latest",
-				Args:    "--rm",
+				Args:    "--rm --cgroups=disabled",
 				Command: "sleep 5",
 			},
 		},

--- a/app/configuration/bundle_software_management_test.go
+++ b/app/configuration/bundle_software_management_test.go
@@ -252,9 +252,6 @@ func Test_SoftwareManagementBundle_InstallPackage_RestartService_WithoutSystemct
 func Test_SoftwareManagementBundle_InstallPackage_RestartService_NotAService(t *testing.T) {
 	r := runner.New(t)
 
-	// install systemctl
-	r.MustExec("apt-get", "install", "-y", "systemctl")
-
 	// execute configuration bundles
 	items := []configuration.Software{{Package: "qbee-test"}}
 
@@ -262,6 +259,8 @@ func Test_SoftwareManagementBundle_InstallPackage_RestartService_NotAService(t *
 
 	expectedReports := []string{
 		"[INFO] Successfully installed 'qbee-test'",
+		// since we are not installing systemctl on the test docker image, we will get the following warning
+		"[WARN] Required restart of 'qbee-test' cannot be performed",
 	}
 	assert.Equal(t, reports, expectedReports)
 }

--- a/app/configuration/bundle_software_management_test.go
+++ b/app/configuration/bundle_software_management_test.go
@@ -268,9 +268,6 @@ func Test_SoftwareManagementBundle_InstallPackage_RestartService_NotAService(t *
 func Test_SoftwareManagementBundle_InstallPackage_RestartService_NoServiceName(t *testing.T) {
 	r := runner.New(t)
 
-	// install systemctl
-	r.MustExec("apt-get", "install", "-y", "systemctl")
-
 	// execute configuration bundles
 	items := []configuration.Software{{Package: "qbee-test-service"}}
 
@@ -284,9 +281,6 @@ func Test_SoftwareManagementBundle_InstallPackage_RestartService_NoServiceName(t
 
 func Test_SoftwareManagementBundle_InstallPackage_RestartService_WithServiceName(t *testing.T) {
 	r := runner.New(t)
-
-	// install systemctl
-	r.MustExec("apt-get", "install", "-y", "systemctl")
 
 	// execute configuration bundles
 	items := []configuration.Software{
@@ -331,9 +325,6 @@ func Test_SoftwareManagementBundle_InstallPackage_PreCondition(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := runner.New(t)
-
-			// install systemctl
-			r.MustExec("apt-get", "install", "-y", "systemctl")
 
 			// execute configuration bundles
 			items := []configuration.Software{{Package: "qbee-test-service", PreCondition: testCase.preCondition}}

--- a/app/utils/runner/runner.go
+++ b/app/utils/runner/runner.go
@@ -140,6 +140,7 @@ func (runner *Runner) FullUpdateCommand() [][]string {
 		return [][]string{
 			{"apt-get", "update"},
 			{"apt-get", "upgrade", "-y"},
+			{"apt-get", "dist-upgrade", "-y"},
 		}
 	case OpenWRT:
 		return [][]string{


### PR DESCRIPTION
This pull request introduces several updates to improve compatibility with newer Debian releases, enhance Docker and Podman integration, and refine test reliability. The changes focus on updating the Docker installation process, adjusting Podman container arguments for better test stability, and ensuring package management commands are comprehensive.

**Docker and Debian compatibility improvements:**
- Updated the Docker installation steps in the `Dockerfile` to use Debian Bookworm, added Docker's official GPG key, and improved the repository setup for more secure and reliable Docker installations.

**Podman test reliability and argument handling:**
- Modified Podman container test arguments in `bundle_podman_containers_test.go` to include `--cgroups=disabled` for better compatibility and reliability in test environments. [[1]](diffhunk://#diff-9705c0fbee4d71bce1274f9f42814e27c0831085b52cc85b2b39bae160e447eaL41-R41) [[2]](diffhunk://#diff-9705c0fbee4d71bce1274f9f42814e27c0831085b52cc85b2b39bae160e447eaL77-R77) [[3]](diffhunk://#diff-9705c0fbee4d71bce1274f9f42814e27c0831085b52cc85b2b39bae160e447eaR114) [[4]](diffhunk://#diff-9705c0fbee4d71bce1274f9f42814e27c0831085b52cc85b2b39bae160e447eaL134-R135)
- Updated the way arguments are appended in tests to avoid overwriting previous values, ensuring cumulative argument changes.

**Package management and systemctl handling:**
- Improved the `FullUpdateCommand` in `runner.go` to include `apt-get dist-upgrade` for more thorough system updates.
- Adjusted the software management bundle test to expect a warning when `systemctl` is not available, reflecting the actual test environment and increasing test accuracy.