### PR TITLE
DEV-2573: pin debian bookworm (support until June 2028)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ RUN echo \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
   tee /etc/apt/sources.list.d/docker.list > /dev/null
 # update apt cache
-#RUN apt-get --allow-releaseinfo-change update && apt-get upgrade -y
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install docker-ce-cli podman -y 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/go \
     -o /usr/sbin/qbee-agent \
     main.go
 
-FROM debian:stable
+FROM debian:bookworm
 
 ARG version
 
@@ -26,14 +26,26 @@ COPY test/resources/debian /apt-repo
 RUN echo "deb [trusted=yes] file:/apt-repo/repo ./" > /etc/apt/sources.list.d/qbee-dev.list
 
 # Install ca-certificates in latest version
-RUN apt-get update && apt-get install -y ca-certificates curl
+RUN apt-get update && \
+  apt-get install -y ca-certificates curl && \
+  install -m 0755 -d /etc/apt/keyrings && \
+  curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+  chmod a+r /etc/apt/keyrings/docker.asc
 
 # add docker repo, so we can install it when needed (disable auth)
 RUN echo 'Acquire::https { Verify-Peer "false" }' > /etc/apt/apt.conf.d/99verify-peer.conf
-RUN echo "deb [trusted=yes] http://download.docker.com/linux/debian bullseye stable" \
+RUN echo "deb [trusted=yes] http://download.docker.com/linux/debian bookworm stable" \
     > /etc/apt/sources.list.d/docker.list
 
+# Add Docker's official GPG key:
+
+# Add the repository to Apt sources:
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
 # update apt cache
+#RUN apt-get --allow-releaseinfo-change update && apt-get upgrade -y
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install docker-ce-cli podman -y 
 


### PR DESCRIPTION
This pull request updates the Docker build environment to use Debian Bookworm and modernizes the Docker repository setup. The changes improve compatibility with newer packages and follow best practices for Docker's official repository configuration.

**Base image and repository updates:**

* Changed the Dockerfile base image from `debian:stable` to `debian:bookworm` to ensure the build uses the latest stable Debian release.
* Updated Docker's APT repository source from `bullseye` to `bookworm` and added the repository using the recommended `signed-by` mechanism with a GPG key stored in `/etc/apt/keyrings/docker.asc`.

**Security and best practices:**

* Added steps to securely download and install Docker's GPG key, create the `/etc/apt/keyrings` directory, and set appropriate file permissions.