### PR TITLE
Add missing files to the RPM package.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -117,6 +117,22 @@ nfpms:
           preremove: package/install-scripts/prerm-rpm
 
         contents:
+          - src: package/share/
+            dst: /opt/qbee/share/
+            type: tree
+            file_info:
+              mode: 0644
+              owner: root
+              group: root
+          
+          - src: package/bin/
+            dst: /opt/qbee/bin
+            type: tree
+            file_info:
+              mode: 0755
+              owner: root
+              group: root
+
           - src: package/init-scripts/systemd/qbee-agent.service
             dst: /usr/lib/systemd/system/qbee-agent.service
             file_info:


### PR DESCRIPTION
This pull request updates the `.goreleaser.yaml` configuration to include additional directories in the package contents. The most important change is the inclusion of the `package/share/` and `package/bin/` directories in the installation, with appropriate permissions and ownership.

Packaging improvements:

* Added the `package/share/` directory to be installed at `/opt/qbee/share/` with mode `0644` and owned by `root:root`.
* Added the `package/bin/` directory to be installed at `/opt/qbee/bin` with mode `0755` and owned by `root:root`.