### PR TITLE
Switch to debian:oldstable-slim for package testing on MIPS64LE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
             platform: arm/v7
             install: dpkg -i ./dist/qbee-agent_${{ github.ref_name }}.0_armhf.deb
 
-          - image: debian:stable-slim
+          - image: debian:oldstable-slim
             platform: mips64le
             install: dpkg -i ./dist/qbee-agent_${{ github.ref_name }}.0_mips64el.deb
 


### PR DESCRIPTION
As Debian deprecated MIPS64LE architecture in favor of RISC-V, this pull request makes changes the Docker image used for the MIPS64LE build job from `debian:stable-slim` to `debian:oldstable-slim`.