### PR TITLE
NOJIRA: Patching

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: stable
+          go-version: 1.25
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.25
+          go-version: 1.25.7
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: stable
+          go-version: 1.25
 
       - name: Build and test
         env:
           UNPRIVILEGED_USER: ${{ matrix.unprivileged }}
         run: make docker-image test-src
-
+          
   vulncheck-and-linters:
     runs-on: ubuntu-latest
     steps:
@@ -35,12 +35,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: stable
+          go-version: 1.25
 
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: stable
+          go-version-input: 1.25
           go-package: ./...
 
       - name: golint

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           UNPRIVILEGED_USER: ${{ matrix.unprivileged }}
         run: make docker-image test-src
-          
+
   vulncheck-and-linters:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25
+          go-version: 1.25.7
 
       - name: Build and test
         env:
@@ -35,12 +35,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25
+          go-version: 1.25.7
 
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.25
+          go-version-input: 1.25.7
           go-package: ./...
 
       - name: golint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: 1.25
 
       - name: Install Cosign for attestation and signing
         uses: sigstore/cosign-installer@v3.9.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.25.7
 
       - name: Install Cosign for attestation and signing
         uses: sigstore/cosign-installer@v3.9.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.3 as builder
+FROM golang:1.25 as builder
 
 ARG version
 ENV VERSION_VAR=go.qbee.io/agent/app.Version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 as builder
+FROM golang:1.25.7 as builder
 
 ARG version
 ENV VERSION_VAR=go.qbee.io/agent/app.Version

--- a/Dockerfile.openwrt
+++ b/Dockerfile.openwrt
@@ -1,4 +1,4 @@
-FROM golang:1.25.3 as builder
+FROM golang:1.25 as builder
 
 ARG version
 ENV VERSION_VAR=go.qbee.io/agent/app.Version

--- a/Dockerfile.openwrt
+++ b/Dockerfile.openwrt
@@ -1,4 +1,4 @@
-FROM golang:1.25 as builder
+FROM golang:1.25.7 as builder
 
 ARG version
 ENV VERSION_VAR=go.qbee.io/agent/app.Version

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -1,4 +1,4 @@
-FROM golang:1.25.3 as builder
+FROM golang:1.25 as builder
 
 ARG version
 ENV VERSION_VAR=go.qbee.io/agent/app.Version

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -1,4 +1,4 @@
-FROM golang:1.25 as builder
+FROM golang:1.25.7 as builder
 
 ARG version
 ENV VERSION_VAR=go.qbee.io/agent/app.Version

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module go.qbee.io/agent
 
-go 1.25.3
+go 1.26
 
 require (
 	github.com/creack/pty v1.1.24
 	github.com/google/go-tpm v0.9.5
 	github.com/google/go-tpm-tools v0.4.5
-	github.com/xtaci/smux v1.5.34
+	github.com/xtaci/smux v1.5.56
 	go.qbee.io/transport v1.25.28
 	golang.org/x/sys v0.38.0
 	google.golang.org/protobuf v1.36.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.qbee.io/agent
 
-go 1.26
+go 1.25
 
 require (
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/xtaci/smux v1.5.34 h1:OUA9JaDFHJDT8ZT3ebwLWPAgEfE6sWo2LaTy3anXqwg=
-github.com/xtaci/smux v1.5.34/go.mod h1:OMlQbT5vcgl2gb49mFkYo6SMf+zP3rcjcwQz7ZU7IGY=
 github.com/xtaci/smux v1.5.56 h1:Eyv/dUULmkGZZNucLUisnkzJ/4UQ5YZTschhugFBM0U=
 github.com/xtaci/smux v1.5.56/go.mod h1:IGQ9QYrBphmb/4aTnLEcJby0TNr3NV+OslIOMrX825Q=
 go.qbee.io/transport v1.25.28 h1:S6X91ORNaRrPsNn3x80gQWAnX4jIyVXG76R8u6dLkKw=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xtaci/smux v1.5.34 h1:OUA9JaDFHJDT8ZT3ebwLWPAgEfE6sWo2LaTy3anXqwg=
 github.com/xtaci/smux v1.5.34/go.mod h1:OMlQbT5vcgl2gb49mFkYo6SMf+zP3rcjcwQz7ZU7IGY=
+github.com/xtaci/smux v1.5.56 h1:Eyv/dUULmkGZZNucLUisnkzJ/4UQ5YZTschhugFBM0U=
+github.com/xtaci/smux v1.5.56/go.mod h1:IGQ9QYrBphmb/4aTnLEcJby0TNr3NV+OslIOMrX825Q=
 go.qbee.io/transport v1.25.28 h1:S6X91ORNaRrPsNn3x80gQWAnX4jIyVXG76R8u6dLkKw=
 go.qbee.io/transport v1.25.28/go.mod h1:SBtAKI5/BjXrXYGRDT04gSjyZxQiuvRApSDeFWeelh4=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=


### PR DESCRIPTION
This pull request updates the Go toolchain and dependencies across the project to use the latest Go 1.25.7 release, ensuring consistency and addressing potential security or compatibility issues. It also bumps the `github.com/xtaci/smux` dependency to a newer version. The most important changes are:

**Go version updates:**

* Updated all workflow files (`.github/workflows/golangci-lint.yml`, `.github/workflows/pr-test.yml`, `.github/workflows/release.yml`) to use Go version 1.25.7 instead of `stable` or 1.25.3, ensuring all CI/CD jobs run with the same Go version. [[1]](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48L21-R21) [[2]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL23-R23) [[3]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL38-R43) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L36-R36)
* Updated all `Dockerfile` variants (`Dockerfile`, `Dockerfile.openwrt`, `Dockerfile.rhel9`) to use `golang:1.25.7` as the build image instead of `golang:1.25.3`. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1) [[2]](diffhunk://#diff-c0701125659e7b77da77e8ddcd29a77795fd5a254bdcab1b55c3f3038ca9e263L1-R1) [[3]](diffhunk://#diff-f9d78ba685ea508dfa4d7e230b6854dc7190d5fefc5d098aec62488493649b3cL1-R1)
* Updated the `go.mod` file to specify `go 1.25` (removing the patch version for compatibility with the new Go release).

**Dependency updates:**

* Bumped `github.com/xtaci/smux` from version `v1.5.34` to `v1.5.56` in `go.mod` for improved features and bug fixes.This pull request standardizes the Go version used throughout the project by updating all references from specific patch versions (`1.25.3`) or the generic `stable` tag to the minor version `1.25`. It also updates the `github.com/xtaci/smux` dependency to a newer version. These changes ensure consistency in the build and CI environments and bring in the latest improvements from the updated dependency.

**Go version standardization:**

* Updated all GitHub Actions workflows (`.github/workflows/golangci-lint.yml`, `.github/workflows/pr-test.yml`, `.github/workflows/release.yml`) to use `go-version: 1.25` instead of `stable` or a specific patch version. [[1]](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48L21-R21) [[2]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL23-R23) [[3]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL38-R43) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L36-R36)
* Changed the base image in `Dockerfile`, `Dockerfile.openwrt`, and `Dockerfile.rhel9` from `golang:1.25.3` to `golang:1.25` for consistent image builds. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1) [[2]](diffhunk://#diff-c0701125659e7b77da77e8ddcd29a77795fd5a254bdcab1b55c3f3038ca9e263L1-R1) [[3]](diffhunk://#diff-f9d78ba685ea508dfa4d7e230b6854dc7190d5fefc5d098aec62488493649b3cL1-R1)
* Updated the `go` directive in `go.mod` from `1.25.3` to `1.25` to match the new standard.

**Dependency updates:**

* Upgraded `github.com/xtaci/smux` from version `v1.5.34` to `v1.5.56` in `go.mod`.