### PR TITLE
NOJIRA: fix reboot privileged command

### DIFF
--- a/app/agent/agent.go
+++ b/app/agent/agent.go
@@ -238,8 +238,9 @@ func (agent *Agent) RebootSystem(ctx context.Context) {
 		return
 	}
 
-	if output, err := utils.RunCommand(ctx, rebootCmd); err != nil {
+	if output, err := utils.RunPrivilegedCommand(ctx, rebootCmd); err != nil {
 		log.Errorf("scheduling system reboot failed: %v", err)
+		return
 	} else {
 		log.Infof("scheduling system reboot completed: %s", output)
 	}

--- a/app/agent/agent.go
+++ b/app/agent/agent.go
@@ -238,12 +238,13 @@ func (agent *Agent) RebootSystem(ctx context.Context) {
 		return
 	}
 
-	if output, err := utils.RunPrivilegedCommand(ctx, rebootCmd); err != nil {
+	var output []byte
+	if output, err = utils.RunPrivilegedCommand(ctx, rebootCmd); err != nil {
 		log.Errorf("scheduling system reboot failed: %v", err)
 		return
-	} else {
-		log.Infof("scheduling system reboot completed: %s", output)
 	}
+
+	log.Infof("scheduling system reboot completed: %s", output)
 
 	agent.stop <- true
 }


### PR DESCRIPTION
This pull request updates the system reboot logic in the `Agent` to improve security and reliability. The main change is switching to a privileged command execution method when scheduling a system reboot.

**System reboot handling:**

* Updated `RebootSystem` in `agent.go` to use `utils.RunPrivilegedCommand` instead of `utils.RunCommand`, ensuring the reboot command is executed with the necessary privileges. The output logging was also adjusted to only occur on success.This pull request makes a small but important change to the system reboot logic in the `Agent` class. The reboot command is now executed using a privileged command runner to ensure proper permissions.

* Changed the reboot command execution in `Agent.RebootSystem` to use `utils.RunPrivilegedCommand` instead of `utils.RunCommand`, improving reliability for privileged operations. (`app/agent/agent.go`)