### PR TITLE
DEV-2557: Bump go version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.25.7
+          go-version: 1.25.9
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.7
+          go-version: 1.25.9
 
       - name: Build and test
         env:
@@ -35,12 +35,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.25.7
+          go-version: 1.25.9
 
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.25.7
+          go-version-input: 1.25.9
           go-package: ./...
 
       - name: golint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.7
+          go-version: 1.25.9
 
       - name: Install Cosign for attestation and signing
         uses: sigstore/cosign-installer@v3.9.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7 as builder
+FROM golang:1.25.9 as builder
 
 ARG version
 ENV VERSION_VAR=go.qbee.io/agent/app.Version

--- a/Dockerfile.openwrt
+++ b/Dockerfile.openwrt
@@ -1,4 +1,4 @@
-FROM golang:1.25.7 as builder
+FROM golang:1.25.9 as builder
 
 ARG version
 ENV VERSION_VAR=go.qbee.io/agent/app.Version

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -1,4 +1,4 @@
-FROM golang:1.25.7 as builder
+FROM golang:1.25.9 as builder
 
 ARG version
 ENV VERSION_VAR=go.qbee.io/agent/app.Version


### PR DESCRIPTION
This pull request updates the Go toolchain version used throughout the project from 1.25.7 to 1.25.9. The change is applied consistently across all Dockerfiles and GitHub Actions workflows to ensure builds, tests, and security checks use the same, more recent Go version.

**Go version update:**

* Updated the Go version from `1.25.7` to `1.25.9` in all Dockerfiles: `Dockerfile`, `Dockerfile.openwrt`, and `Dockerfile.rhel9` [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1) [[2]](diffhunk://#diff-c0701125659e7b77da77e8ddcd29a77795fd5a254bdcab1b55c3f3038ca9e263L1-R1) [[3]](diffhunk://#diff-f9d78ba685ea508dfa4d7e230b6854dc7190d5fefc5d098aec62488493649b3cL1-R1).
* Updated the Go version from `1.25.7` to `1.25.9` in GitHub Actions workflows for linting, testing, vulnerability checks, and release: `.github/workflows/golangci-lint.yml`, `.github/workflows/pr-test.yml`, and `.github/workflows/release.yml` [[1]](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48L21-R21) [[2]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL23-R23) [[3]](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL38-R43) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L36-R36).