### PR TITLE
DEV-2992: Prevent symlink-following in privileged file writes

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.25.9
+          go-version: 1.26
 
       - name: Build and test
         env:
@@ -33,14 +33,14 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.25.9
+          go-version: 1.26
 
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.25.9
+          go-version-input: 1.26
           go-package: ./...
 
       - name: golint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.9
+          go-version: 1.25
 
       - name: Install Cosign for attestation and signing
         uses: sigstore/cosign-installer@v3.9.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
 
       - name: Install Cosign for attestation and signing
         uses: sigstore/cosign-installer@v3.9.2

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -491,13 +491,18 @@ func calculateTemplateDigest(src string, params map[string]string) (string, erro
 }
 
 // createFile under provided path and with provided uid and gid.
+//
+// The agent typically runs as root, so all path resolution here must refuse
+// to follow attacker-controlled symlinks (CWE-59). makeDirectories rejects
+// symlinked intermediate components; O_NOFOLLOW rejects a symlinked final
+// component so we never open, truncate, or chown an attacker-chosen target.
 func createFile(path string, fileCreateData *fileCreateData, permission os.FileMode, truncate bool) (*os.File, error) {
 	var err error
 	if err = makeDirectories(path, fileManagerDefaultDirectoryPermission, fileCreateData.uid, fileCreateData.gid); err != nil {
 		return nil, err
 	}
 
-	openFlags := os.O_RDWR | os.O_CREATE
+	openFlags := os.O_RDWR | os.O_CREATE | syscall.O_NOFOLLOW
 
 	if truncate {
 		openFlags = openFlags | os.O_TRUNC
@@ -608,6 +613,10 @@ func determineFileCreateData(dst string) (*fileCreateData, error) {
 }
 
 // makeDirectories checks if all directories for the dst file exist, if not, create them with provided owner and group.
+//
+// All ancestor components are inspected with os.Lstat so that a symlinked
+// directory (e.g. an attacker's ~/.ssh pointing at /root/.ssh) is rejected
+// rather than transparently traversed by the kernel (CWE-59).
 func makeDirectories(dst string, permissions os.FileMode, uid, gid int) error {
 	if dst == "/" {
 		return nil
@@ -615,13 +624,14 @@ func makeDirectories(dst string, permissions os.FileMode, uid, gid int) error {
 
 	dirPath := filepath.Dir(dst)
 
-	dirInfo, err := os.Stat(dirPath)
-	if errors.Is(err, os.ErrNotExist) {
-		// ensure parent exists
-		if err = makeDirectories(dirPath, permissions, uid, gid); err != nil {
-			return err
-		}
+	// Always validate / materialize ancestors first so that symlinks higher
+	// up the path are caught even when dirPath itself already exists.
+	if err := makeDirectories(dirPath, permissions, uid, gid); err != nil {
+		return err
+	}
 
+	dirInfo, err := os.Lstat(dirPath)
+	if errors.Is(err, os.ErrNotExist) {
 		if err = os.Mkdir(dirPath, permissions); err != nil {
 			return fmt.Errorf("cannot create directorty %s: %w", dirPath, err)
 		}
@@ -635,6 +645,10 @@ func makeDirectories(dst string, permissions os.FileMode, uid, gid int) error {
 
 	if err != nil {
 		return fmt.Errorf("cannot create directory %s: %w", dirPath, err)
+	}
+
+	if dirInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to traverse symlinked path component %s", dirPath)
 	}
 
 	if !dirInfo.IsDir() {

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -19,6 +19,7 @@ package configuration
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -202,4 +203,133 @@ func Test_resolveDestinationPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_createFile_doesNotFollowSymlinks reproduces the symlink-following
+// vulnerability in createFile() (file_manager.go). createFile is invoked by
+// the root daemon to materialize files such as ~user/.ssh/authorized_keys
+// (bundle_sshkeys.go) and the RAUC partial-download staging file
+// (/tmp/.bundle.raucb.part). It opens the path with os.OpenFile using
+// O_RDWR|O_CREATE[|O_TRUNC] and no O_NOFOLLOW, and its companion
+// makeDirectories() uses symlink-following os.Stat. A local unprivileged
+// user who controls a path component can therefore redirect a
+// root-privileged write/chown through a symlink and clobber an arbitrary
+// root-owned file (CWE-59).
+//
+// Each subtest below sets up a "victim" file the attacker should not be
+// able to touch, plants a symlink representing the attacker-controlled
+// component, then calls createFile() through the attacker-controlled
+// path. A safe implementation must either fail or write to a fresh,
+// non-symlinked location; in particular the victim file's contents must
+// remain unchanged.
+func Test_createFile_doesNotFollowSymlinks(t *testing.T) {
+	t.Run("symlinked intermediate directory (authorized_keys variant)", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		// Victim directory + file, simulating /root/.ssh/authorized_keys
+		// that already holds root's real key material.
+		victimDir := filepath.Join(tempDir, "root_ssh")
+		if err := os.Mkdir(victimDir, 0700); err != nil {
+			t.Fatalf("setup: mkdir victim dir: %v", err)
+		}
+		victimFile := filepath.Join(victimDir, "authorized_keys")
+		victimContent := []byte("root-original-authorized-keys\n")
+		if err := os.WriteFile(victimFile, victimContent, 0600); err != nil {
+			t.Fatalf("setup: write victim file: %v", err)
+		}
+
+		// Attacker's home directory (a directory the unprivileged user owns
+		// — non-sticky, so fs.protected_symlinks does not mitigate).
+		attackerHome := filepath.Join(tempDir, "alice_home")
+		if err := os.Mkdir(attackerHome, 0700); err != nil {
+			t.Fatalf("setup: mkdir attacker home: %v", err)
+		}
+
+		// Attacker plants ~alice/.ssh -> /root/.ssh (the victim dir).
+		sshSymlink := filepath.Join(attackerHome, ".ssh")
+		if err := os.Symlink(victimDir, sshSymlink); err != nil {
+			t.Fatalf("setup: plant symlink: %v", err)
+		}
+
+		// The root daemon computes filepath.Join(user.HomeDirectory, ".ssh",
+		// "authorized_keys") and hands it to createFile.
+		targetPath := filepath.Join(sshSymlink, "authorized_keys")
+
+		fcd := &fileCreateData{
+			uid:        os.Geteuid(),
+			gid:        os.Getegid(),
+			bytesAvail: 1 << 30,
+		}
+
+		file, err := createFile(targetPath, fcd, sshAuthorizedKeysFilePermission, true)
+		if file != nil {
+			_, _ = file.Write([]byte("attacker-supplied-key\n"))
+			_ = file.Close()
+		}
+		if err == nil {
+			t.Errorf("createFile traversed a symlinked intermediate directory and returned no error; "+
+				"expected it to refuse the symlinked .ssh path (target=%s)", targetPath)
+		}
+
+		got, readErr := os.ReadFile(victimFile)
+		if readErr != nil {
+			t.Fatalf("reading victim file: %v", readErr)
+		}
+		if !bytes.Equal(got, victimContent) {
+			t.Errorf("victim file was overwritten through a symlinked intermediate directory.\n"+
+				" path:     %s\n want:     %q\n got:      %q",
+				victimFile, victimContent, got)
+		}
+	})
+
+	t.Run("symlinked final component (RAUC /tmp staging variant)", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		// Victim file the attacker should not be able to overwrite/chown
+		// (simulating e.g. /etc/shadow being targeted via the predictable
+		// /tmp/.bundle.raucb.part staging path).
+		victimFile := filepath.Join(tempDir, "victim_root_file")
+		victimContent := []byte("important-root-owned-content\n")
+		if err := os.WriteFile(victimFile, victimContent, 0600); err != nil {
+			t.Fatalf("setup: write victim file: %v", err)
+		}
+
+		// Predictable staging location in an attacker-writable dir.
+		stagingDir := filepath.Join(tempDir, "tmp")
+		if err := os.Mkdir(stagingDir, 0777); err != nil {
+			t.Fatalf("setup: mkdir staging dir: %v", err)
+		}
+		stagingPath := filepath.Join(stagingDir, ".bundle.raucb.part")
+
+		// Attacker pre-creates the staging path as a symlink to the victim.
+		if err := os.Symlink(victimFile, stagingPath); err != nil {
+			t.Fatalf("setup: plant staging symlink: %v", err)
+		}
+
+		fcd := &fileCreateData{
+			uid:        os.Geteuid(),
+			gid:        os.Getegid(),
+			bytesAvail: 1 << 30,
+		}
+
+		file, err := createFile(stagingPath, fcd, fileManagerDefaultFilePermission, true)
+		if file != nil {
+			_, _ = file.Write([]byte("server-bundle-bytes\n"))
+			_ = file.Close()
+		}
+		if err == nil {
+			t.Errorf("createFile opened a final-component symlink without O_NOFOLLOW and returned no error; "+
+				"expected it to refuse the symlinked staging path (target=%s)", stagingPath)
+		}
+
+		got, readErr := os.ReadFile(victimFile)
+		if readErr != nil {
+			t.Fatalf("reading victim file: %v", readErr)
+		}
+		if !bytes.Equal(got, victimContent) {
+			t.Errorf("victim file was truncated/overwritten through a final-component symlink.\n"+
+				" path:     %s\n want:     %q\n got:      %q",
+				victimFile, victimContent, got)
+		}
+	})
 }


### PR DESCRIPTION
This pull request strengthens the security of file creation in the `file_manager.go` module by ensuring the code does not follow attacker-controlled symlinks, which could otherwise lead to privilege escalation vulnerabilities (CWE-59). The changes include both code updates to prevent symlink traversal and new tests to verify this behavior.

**Security hardening:**

* Updated `createFile` to use the `O_NOFOLLOW` flag when opening files, preventing the function from following symlinks for the final path component.
* Modified `makeDirectories` to use `os.Lstat` instead of `os.Stat` for ancestor directories, ensuring symlinked directories are detected and rejected rather than transparently traversed.
* Added an explicit check in `makeDirectories` to refuse traversal of any symlinked path component.

**Testing improvements:**

* Added a new test, `Test_createFile_doesNotFollowSymlinks`, that simulates two attack scenarios (symlinked intermediate directory and symlinked final component) to ensure that privileged files cannot be overwritten or truncated via symlinks.
* Imported `os` in the test file to support new test logic.

**Acknowledgments:**

The issue has been reported first by @ttzero25 and a few days later by @SEORY0 as part of our Vulnerability Disclosure program.