### PR TITLE
Update TPM private key sealing

### DIFF
--- a/app/agent/credentials.go
+++ b/app/agent/credentials.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"math/big"
 	"os"
 	"path/filepath"
 
@@ -111,7 +110,13 @@ func (agent *Agent) createPrivateKey() error {
 
 	if agent.cfg.TPMDevice != "" {
 		pemBlock.Type = sealedECPrivateKeyPEMHeader
-		if pemBlock.Bytes, err = agent.SealSecret(privateKey.D.Bytes()); err != nil {
+
+		dBytes, err := privateKey.Bytes()
+		if err != nil {
+			return fmt.Errorf("error getting private key D bytes: %w", err)
+		}
+
+		if pemBlock.Bytes, err = agent.SealSecret(dBytes); err != nil {
 			return err
 		}
 	}
@@ -127,6 +132,8 @@ func (agent *Agent) createPrivateKey() error {
 
 	return nil
 }
+
+const p521ElementLength = 66
 
 // loadPrivateKey loads private key from the config directory.
 func (agent *Agent) loadPrivateKey() error {
@@ -148,14 +155,17 @@ func (agent *Agent) loadPrivateKey() error {
 			return err
 		}
 
-		x, y := elliptic.P521().ScalarBaseMult(dBytes)
-		agent.privateKey = &ecdsa.PrivateKey{
-			D: new(big.Int).SetBytes(dBytes),
-			PublicKey: ecdsa.PublicKey{
-				Curve: elliptic.P521(),
-				X:     x,
-				Y:     y,
-			},
+		// due to previous use of privateKey.D.Bytes()
+		// (which might have returned a shorter byte slice for sealed key),
+		// we need pad the byte slice to ensure it has the correct length for P-521 curve
+		if len(dBytes) < p521ElementLength {
+			padding := make([]byte, p521ElementLength-len(dBytes))
+			dBytes = append(padding, dBytes...)
+		}
+
+		agent.privateKey, err = ecdsa.ParseRawPrivateKey(elliptic.P521(), dBytes)
+		if err != nil {
+			return fmt.Errorf("error parsing sealed private key: %w", err)
 		}
 	} else {
 		if agent.privateKey, err = x509.ParseECPrivateKey(pemBlock.Bytes); err != nil {


### PR DESCRIPTION
This pull request refactors how P-521 ECDSA private keys are serialized and deserialized due to deprecation of internal fields and avoiding use of low-level crypto functions. The new version is fully backwards compatible with already sealed keys.

**ECDSA P-521 Private Key Handling Improvements**

- **Serialization and Deserialization Consistency**
  * The code now uses `privateKey.Bytes()` for serialization and `ecdsa.ParseRawPrivateKey` for deserialization, replacing direct use of `privateKey.D.Bytes()` and manual key construction. This ensures the private key bytes are always in the correct format. [[1]](diffhunk://#diff-ce11332caa12b625dfb6e9f48ab213880ea4cc9fc55f5d31cc37b5b96a26518bL114-R119) [[2]](diffhunk://#diff-ce11332caa12b625dfb6e9f48ab213880ea4cc9fc55f5d31cc37b5b96a26518bL151-R168)
  * Introduced padding for private key bytes to match the expected length (`p521ElementLength`) before deserialization, preventing errors when the key bytes are shorter than required. [[1]](diffhunk://#diff-ce11332caa12b625dfb6e9f48ab213880ea4cc9fc55f5d31cc37b5b96a26518bR136-R137) [[2]](diffhunk://#diff-ce11332caa12b625dfb6e9f48ab213880ea4cc9fc55f5d31cc37b5b96a26518bL151-R168)

- **Code Cleanup**
  * Removed the unnecessary import of `"math/big"` since manual construction of the private key from big integers is no longer needed.

These updates improve reliability when loading and storing TPM-sealed ECDSA P-521 keys.