### PR TITLE
DEV-3011: Fix report redacting for empty/whitespace only secrets

### DIFF
--- a/app/configuration/report.go
+++ b/app/configuration/report.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -92,6 +93,13 @@ func (reporter *Reporter) Redact(value string) string {
 
 // NewReporter returns a new instance of Reporter.
 func NewReporter(commitID string, reportToConsole bool, secrets []string) *Reporter {
+
+	// delete secrets which are empty or consist of whitespace only
+	// otherwise all spaces and empty strings in the log would be replaced with redactedValue
+	secrets = slices.DeleteFunc(secrets, func(secret string) bool {
+		return strings.TrimSpace(secret) == ""
+	})
+
 	return &Reporter{
 		commitID:        commitID,
 		reports:         make([]Report, 0),

--- a/app/configuration/report_test.go
+++ b/app/configuration/report_test.go
@@ -66,6 +66,24 @@ func Test_Reporter_Redact(t *testing.T) {
 			expectedReportText: "log message",
 			expectedReportLog:  "recording ******** in extra log",
 		},
+		{
+			name:    "reporter with empty secret",
+			secrets: []string{""},
+			testFn: func(ctx context.Context) {
+				ReportInfo(ctx, "extra log", "log message")
+			},
+			expectedReportText: "log message",
+			expectedReportLog:  "extra log",
+		},
+		{
+			name:    "reporter with secret consisting of whitespace",
+			secrets: []string{" "},
+			testFn: func(ctx context.Context) {
+				ReportInfo(ctx, "extra log", "log message")
+			},
+			expectedReportText: "log message",
+			expectedReportLog:  "extra log",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
This pull request improves the handling of secrets in the `Reporter` by ensuring that empty strings and whitespace-only secrets are filtered out before being used. This prevents unnecessary or incorrect redactions in logs. Additionally, corresponding tests have been added to verify this behavior.

Secret filtering improvements:

* Updated the `NewReporter` constructor in `report.go` to remove secrets that are empty or contain only whitespace, preventing them from being used for redaction.
* Added the `slices` package import to support the new filtering logic.

Testing enhancements:

* Added test cases in `report_test.go` to ensure that reporters initialized with empty or whitespace-only secrets do not alter log output unnecessarily.