### PR TITLE
Upgrade go.qbee.io/transport to patch CVE-2026-55828

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/go-tpm v0.9.8
 	github.com/google/go-tpm-tools v0.4.5
 	github.com/xtaci/smux v1.5.57
-	go.qbee.io/transport v1.26.25
+	go.qbee.io/transport v1.26.27
 	golang.org/x/sys v0.46.0
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xtaci/smux v1.5.57 h1:N72VbGoSYxgcm6mPOYX0QzEZNVD3UI/JlVvAtXF+WrY=
 github.com/xtaci/smux v1.5.57/go.mod h1:IGQ9QYrBphmb/4aTnLEcJby0TNr3NV+OslIOMrX825Q=
-go.qbee.io/transport v1.26.25 h1:HUckZV5Umn6bFulEZ+sGx13RFJr2ZtfDLkFikxDaR58=
-go.qbee.io/transport v1.26.25/go.mod h1:SBtAKI5/BjXrXYGRDT04gSjyZxQiuvRApSDeFWeelh4=
+go.qbee.io/transport v1.26.27 h1:1rFlza8Doh/tPa1rHh0Z6H31cb9X/G+NTtYtIZgWAhU=
+go.qbee.io/transport v1.26.27/go.mod h1:SBtAKI5/BjXrXYGRDT04gSjyZxQiuvRApSDeFWeelh4=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=


### PR DESCRIPTION
This pull request updates the `go.qbee.io/transport` dependency in the `go.mod` file to a newer version. This is a minor dependency update.

* Updated `go.qbee.io/transport` from version `v1.26.25` to `v1.26.27` in `go.mod` to incorporate the latest bug fixes and improvements.