### PR TITLE
DEV-2788: Non-blocking read operations on kernel filesystems

### DIFF
--- a/app/agent/agent.go
+++ b/app/agent/agent.go
@@ -210,7 +210,7 @@ func (agent *Agent) doMetrics(ctx context.Context) error {
 		return nil
 	}
 
-	if err := agent.Metrics.Send(ctx, agent.Metrics.Collect()); err != nil {
+	if err := agent.Metrics.Send(ctx, agent.Metrics.Collect(ctx)); err != nil {
 		return fmt.Errorf("failed to send metrics: %w", err)
 	}
 

--- a/app/agent/agent.go
+++ b/app/agent/agent.go
@@ -173,6 +173,15 @@ func (agent *Agent) RunOnce(ctx context.Context, mode RunOnceMode) {
 	agent.Configuration.UpdateSettings(configData)
 	agent.Configuration.UpdateMetricsMonitorState(configData)
 
+	// Check if we have enough goroutine budget to run the agent, if not, skip the run.
+	// Do this after we have updated the configuration, so that the device is online.
+	if exhausted, err := agent.Configuration.ReportExhaustedGoroutineBudget(ctx); exhausted {
+		if err != nil {
+			log.Errorf("failed to report goroutine budget: %v", err)
+		}
+		return
+	}
+
 	if mode == FullRun {
 		agent.do(ctx, "check-in", agent.checkIn)
 		agent.do(ctx, "remote-access", agent.doRemoteAccess(configData))

--- a/app/agent/bootstrap.go
+++ b/app/agent/bootstrap.go
@@ -58,7 +58,7 @@ func Bootstrap(ctx context.Context, cfg *Config) error {
 	}
 
 	var bootstrapRequest *BootstrapRequest
-	bootstrapRequest, err = agent.newBootstrapRequest()
+	bootstrapRequest, err = agent.newBootstrapRequest(ctx)
 	if err != nil {
 		return err
 	}
@@ -142,10 +142,10 @@ func (agent *Agent) getRawPublicKey() ([]string, error) {
 }
 
 // newBootstrapRequest returns a new BootstrapRequest for the agent.
-func (agent *Agent) newBootstrapRequest() (*BootstrapRequest, error) {
+func (agent *Agent) newBootstrapRequest(ctx context.Context) (*BootstrapRequest, error) {
 	log.Infof("Gathering system information")
 
-	systemInventory, err := inventory.CollectSystemInventory(agent.IsTPMEnabled())
+	systemInventory, err := inventory.CollectSystemInventory(ctx, agent.IsTPMEnabled())
 	if err != nil {
 		return nil, fmt.Errorf("error collecting system info: %w", err)
 	}

--- a/app/agent/inventory.go
+++ b/app/agent/inventory.go
@@ -61,7 +61,7 @@ func (agent *Agent) doInventories(ctx context.Context) error {
 
 // doSystemInventory collects system inventory and delivers it to the device hub API.
 func (agent *Agent) doSystemInventory(ctx context.Context) error {
-	systemInventory, err := inventory.CollectSystemInventory(agent.IsTPMEnabled())
+	systemInventory, err := inventory.CollectSystemInventory(ctx, agent.IsTPMEnabled())
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (agent *Agent) doUsersInventory(ctx context.Context) error {
 
 // doPortsInventory collects ports inventory and delivers it to the device hub API.
 func (agent *Agent) doPortsInventory(ctx context.Context) error {
-	portsInventory, err := inventory.CollectPortsInventory()
+	portsInventory, err := inventory.CollectPortsInventory(ctx)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func (agent *Agent) doProcessInventory(ctx context.Context) error {
 		return nil
 	}
 
-	processesInventory, err := inventory.CollectProcessesInventory()
+	processesInventory, err := inventory.CollectProcessesInventory(ctx)
 	if err != nil {
 		return err
 	}

--- a/app/cmd/inventory.go
+++ b/app/cmd/inventory.go
@@ -68,11 +68,11 @@ var inventoryCommand = cmd.Command{
 
 		switch inventoryType {
 		case inventory.TypeSystem:
-			inventoryData, err = inventory.CollectSystemInventory(cfg.TPMDevice != "")
+			inventoryData, err = inventory.CollectSystemInventory(ctx, cfg.TPMDevice != "")
 		case inventory.TypePorts:
-			inventoryData, err = inventory.CollectPortsInventory()
+			inventoryData, err = inventory.CollectPortsInventory(ctx)
 		case inventory.TypeProcesses:
-			inventoryData, err = inventory.CollectProcessesInventory()
+			inventoryData, err = inventory.CollectProcessesInventory(ctx)
 		case inventory.TypeUsers:
 			inventoryData, err = inventory.CollectUsersInventory()
 		case inventory.TypeSoftware:

--- a/app/configuration/bundle_metrics_monitor.go
+++ b/app/configuration/bundle_metrics_monitor.go
@@ -90,7 +90,7 @@ func init() {
 // Execute the metrics monitor bundle.
 func (m *MetricsMonitorBundle) Execute(ctx context.Context, service *Service) error {
 
-	collectedMetrics := service.metrics.Collect()
+	collectedMetrics := service.metrics.Collect(ctx)
 
 	reports, err := m.EvaluateMonitors(collectedMetrics)
 	if err != nil {

--- a/app/configuration/bundle_metrics_monitor_test.go
+++ b/app/configuration/bundle_metrics_monitor_test.go
@@ -74,7 +74,7 @@ func Test_Monitor_State_Set(t *testing.T) {
 	}
 
 	metricsService := metrics.New(nil)
-	collectedMetrics := metricsService.Collect()
+	collectedMetrics := metricsService.Collect(t.Context())
 	reports, err := metricsMonitorBundle.EvaluateMonitors(collectedMetrics)
 
 	if err != nil {
@@ -83,7 +83,7 @@ func Test_Monitor_State_Set(t *testing.T) {
 
 	assert.Equal(t, len(reports), 1)
 
-	collectedMetrics = metricsService.Collect()
+	collectedMetrics = metricsService.Collect(t.Context())
 	reports, err = metricsMonitorBundle.EvaluateMonitors(collectedMetrics)
 
 	if err != nil {
@@ -106,7 +106,7 @@ func Test_Monitor_State_Reset(t *testing.T) {
 	}
 
 	metricsService := metrics.New(nil)
-	collectedMetrics := metricsService.Collect()
+	collectedMetrics := metricsService.Collect(t.Context())
 	reports, err := metricsMonitorBundle.EvaluateMonitors(collectedMetrics)
 
 	if err != nil {
@@ -124,7 +124,7 @@ func Test_Monitor_State_Reset(t *testing.T) {
 		},
 	}
 
-	collectedMetrics = metricsService.Collect()
+	collectedMetrics = metricsService.Collect(t.Context())
 	reports, err = metricsMonitorBundle.EvaluateMonitors(collectedMetrics)
 
 	if err != nil {
@@ -133,13 +133,6 @@ func Test_Monitor_State_Reset(t *testing.T) {
 
 	// Monitor has changed value, we should get a new report
 	assert.Equal(t, len(reports), 1)
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	assert.Equal(t, len(reports), 1)
-
 }
 
 func Test_Monitor_State_Delete(t *testing.T) {
@@ -154,7 +147,7 @@ func Test_Monitor_State_Delete(t *testing.T) {
 	}
 
 	metricsService := metrics.New(nil)
-	collectedMetrics := metricsService.Collect()
+	collectedMetrics := metricsService.Collect(t.Context())
 	reports, err := metricsMonitorBundle.EvaluateMonitors(collectedMetrics)
 
 	if err != nil {

--- a/app/configuration/bundle_parameters.go
+++ b/app/configuration/bundle_parameters.go
@@ -94,49 +94,49 @@ var systemParameters = map[string]func(ctx context.Context) (string, error){
 		return string(software.DefaultPackageManager.Type()), nil
 	},
 	"sys.os": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.OS, nil
 	},
 	"sys.arch": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.Architecture, nil
 	},
 	"sys.os_type": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.OSType, nil
 	},
 	"sys.flavor": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.Flavor, nil
 	},
 	"sys.agent_version": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.AgentVersion, nil
 	},
 	"sys.long_arch": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.LongArchitecture, nil
 	},
 	"sys.boot_time": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}

--- a/app/configuration/bundle_parameters_test.go
+++ b/app/configuration/bundle_parameters_test.go
@@ -54,7 +54,7 @@ func Test_resolveParameters(t *testing.T) {
 
 	pkgType := software.DefaultPackageManager.Type()
 
-	systemInventory, err := inventory.CollectSystemInventory(false)
+	systemInventory, err := inventory.CollectSystemInventory(t.Context(), false)
 	assert.NoError(t, err)
 
 	invSystem := systemInventory.System

--- a/app/configuration/bundle_process_watch.go
+++ b/app/configuration/bundle_process_watch.go
@@ -51,7 +51,7 @@ type ProcessWatchBundle struct {
 
 // Execute ensures that watched processes are in a correct state.
 func (p ProcessWatchBundle) Execute(ctx context.Context, _ *Service) error {
-	runningProcesses, err := linux.ListRunningProcessesNames()
+	runningProcesses, err := linux.ListRunningProcessesNames(ctx)
 	if err != nil {
 		return fmt.Errorf("cannot list running processes: %w", err)
 	}

--- a/app/configuration/config.go
+++ b/app/configuration/config.go
@@ -37,6 +37,9 @@ const (
 	BundleRauc                 = "rauc"
 	BundleMetricsMonitor       = "metrics_monitor"
 	BundleDockerCompose        = "docker_compose"
+
+	// bundleAgentInternal is an internal bundle that is not exposed to the user.
+	bundleAgentInternal = "agent_internal"
 )
 
 // CommittedConfig contains the configuration that is committed.

--- a/app/configuration/service.go
+++ b/app/configuration/service.go
@@ -340,7 +340,7 @@ func (srv *Service) ReportExhaustedGoroutineBudget(ctx context.Context) (bool, e
 
 	ReportError(bundleCtx, nil, "goroutine budget exhausted, skipping agent run")
 
-	// send reports immedately as there will be no further configurations executed, thus
+	// send reports immediately as there will be no further configurations executed, thus
 	// no further reports will be generated. If we fail to send the reports, we add them to the buffer.
 	if _, err := srv.sendReports(ctx, reporter.Reports()); err != nil {
 		log.Debugf("failed to send reports to the server: %v, adding to the buffer", err)

--- a/app/configuration/service.go
+++ b/app/configuration/service.go
@@ -330,18 +330,34 @@ func (srv *Service) reportAPIError(ctx context.Context, err error) {
 }
 
 func (srv *Service) ReportExhaustedGoroutineBudget(ctx context.Context) (bool, error) {
-	if utils.GoroutinesExhausted() {
-		// since we don't have a reporter defined on this context, we need to create a new one
-		reporter := NewReporter(srv.currentCommitID, srv.reportToConsole, nil)
-		bundleCtx := reporter.BundleContext(ctx, bundleAgentInternal, "")
-
-		ReportError(bundleCtx, nil, "goroutine budget exhausted, skipping agent run")
-
-		// send reports immedately as there will be no further configurations executed, thus
-		// no further reports will be generated. If we fail to send the reports, we add them to the buffer.
-		return true, srv.flushReportsBuffer(ctx)
+	if !utils.GoroutinesExhausted() {
+		return false, nil
 	}
-	return false, nil
+
+	// since we don't have a reporter defined on this context, we need to create a new one
+	reporter := NewReporter(srv.currentCommitID, srv.reportToConsole, nil)
+	bundleCtx := reporter.BundleContext(ctx, bundleAgentInternal, "")
+
+	ReportError(bundleCtx, nil, "goroutine budget exhausted, skipping agent run")
+
+	// send reports immedately as there will be no further configurations executed, thus
+	// no further reports will be generated. If we fail to send the reports, we add them to the buffer.
+	if _, err := srv.sendReports(ctx, reporter.Reports()); err != nil {
+		log.Debugf("failed to send reports to the server: %v, adding to the buffer", err)
+
+		if bufferErr := srv.addReportsToBuffer(reporter.Reports()); bufferErr != nil {
+			log.Errorf("failed to add reports to buffer: %v", bufferErr)
+		}
+
+		return true, err
+	}
+
+	// also flush any existing buffered reports
+	if err := srv.flushReportsBuffer(ctx); err != nil {
+		log.Errorf("failed to flush reports buffer: %v", err)
+	}
+
+	return true, nil
 }
 
 // RunIntervalChangedNotifier returns a channel which will send a new agent interval duration when it changes.

--- a/app/configuration/service.go
+++ b/app/configuration/service.go
@@ -30,6 +30,7 @@ import (
 	"go.qbee.io/agent/app/api"
 	"go.qbee.io/agent/app/log"
 	"go.qbee.io/agent/app/metrics"
+	"go.qbee.io/agent/app/utils"
 )
 
 const defaultAgentInterval = 5 // minutes
@@ -326,6 +327,21 @@ func (srv *Service) reportAPIError(ctx context.Context, err error) {
 			log.Errorf("failed to add reports to buffer: %v", err)
 		}
 	}
+}
+
+func (srv *Service) ReportExhaustedGoroutineBudget(ctx context.Context) (bool, error) {
+	if utils.GoroutinesExhausted() {
+		// since we don't have a reporter defined on this context, we need to create a new one
+		reporter := NewReporter(srv.currentCommitID, srv.reportToConsole, nil)
+		bundleCtx := reporter.BundleContext(ctx, bundleAgentInternal, "")
+
+		ReportError(bundleCtx, nil, "goroutine budget exhausted, skipping agent run")
+
+		// send reports immedately as there will be no further configurations executed, thus
+		// no further reports will be generated. If we fail to send the reports, we add them to the buffer.
+		return true, srv.flushReportsBuffer(ctx)
+	}
+	return false, nil
 }
 
 // RunIntervalChangedNotifier returns a channel which will send a new agent interval duration when it changes.

--- a/app/configuration/service_test.go
+++ b/app/configuration/service_test.go
@@ -236,39 +236,14 @@ func TestService_ReportExhaustedGoroutineBudget(t *testing.T) {
 	exhausted, _ := srv.ReportExhaustedGoroutineBudget(context.Background())
 
 	// Verify that it returns true (indicating budget was exhausted)
-	if !exhausted {
-		t.Fatalf("expected exhausted to be true, got false")
-	}
+	assert.True(t, exhausted)
 
 	// Read the buffered reports
 	reports, readErr := srv.readReportsBuffer()
-	if readErr != nil {
-		t.Fatalf("failed to read reports buffer: %v", readErr)
-	}
+	assert.NoError(t, readErr)
+	assert.NotEqual(t, len(reports), 0)
 
-	// Verify that at least one report was created
-	if len(reports) == 0 {
-		t.Fatalf("expected reports to be buffered, but got none")
-	}
-
-	// Verify the report contains the expected error message
-	found := false
-	for _, report := range reports {
-		if report.Text == "goroutine budget exhausted, skipping agent run" {
-			found = true
-			// Verify the bundle is set correctly
-			if report.Bundle != "agent_internal" {
-				t.Fatalf("expected bundle to be 'agent_internal', got %q", report.Bundle)
-			}
-			// Verify the severity is ERR
-			if report.Severity != "ERR" {
-				t.Fatalf("expected severity to be 'ERR', got %q", report.Severity)
-			}
-			break
-		}
-	}
-
-	if !found {
-		t.Fatalf("expected report with text 'goroutine budget exhausted, skipping agent run', but got reports: %v", reports)
-	}
+	assert.Equal(t, reports[0].Bundle, bundleAgentInternal)
+	assert.Equal(t, reports[0].Severity, severityError)
+	assert.Equal(t, reports[0].Text, "goroutine budget exhausted, skipping agent run")
 }

--- a/app/configuration/service_test.go
+++ b/app/configuration/service_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/utils"
 	"go.qbee.io/agent/app/utils/assert"
 )
 
@@ -214,5 +215,60 @@ func Test_ConfigEndpointBooleanReset(t *testing.T) {
 	// config endpoint should now be reachable
 	if srv.IsConfigEndpointUnreachable() {
 		t.Fatalf("expected config endpoint to be reachable")
+	}
+}
+
+func TestService_ReportExhaustedGoroutineBudget(t *testing.T) {
+	tmpDir := t.TempDir()
+	srv := New(nil, tmpDir, "")
+	srv.currentCommitID = "test-commit-id"
+
+	// Create a mock API client that will fail to send reports
+	// so they get buffered to the reports file
+	mockClient := api.NewClient("localhost", "99999")
+	srv.api = mockClient
+
+	// Simulate exhausted goroutine budget
+	utils.SetGoroutineCountForTesting(500)     // maxGoroutines is 500
+	defer utils.SetGoroutineCountForTesting(0) // reset after test
+
+	// Call ReportExhaustedGoroutineBudget
+	exhausted, _ := srv.ReportExhaustedGoroutineBudget(context.Background())
+
+	// Verify that it returns true (indicating budget was exhausted)
+	if !exhausted {
+		t.Fatalf("expected exhausted to be true, got false")
+	}
+
+	// Read the buffered reports
+	reports, readErr := srv.readReportsBuffer()
+	if readErr != nil {
+		t.Fatalf("failed to read reports buffer: %v", readErr)
+	}
+
+	// Verify that at least one report was created
+	if len(reports) == 0 {
+		t.Fatalf("expected reports to be buffered, but got none")
+	}
+
+	// Verify the report contains the expected error message
+	found := false
+	for _, report := range reports {
+		if report.Text == "goroutine budget exhausted, skipping agent run" {
+			found = true
+			// Verify the bundle is set correctly
+			if report.Bundle != "agent_internal" {
+				t.Fatalf("expected bundle to be 'agent_internal', got %q", report.Bundle)
+			}
+			// Verify the severity is ERR
+			if report.Severity != "ERR" {
+				t.Fatalf("expected severity to be 'ERR', got %q", report.Severity)
+			}
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected report with text 'goroutine budget exhausted, skipping agent run', but got reports: %v", reports)
 	}
 }

--- a/app/inventory/linux/mem_info.go
+++ b/app/inventory/linux/mem_info.go
@@ -19,6 +19,7 @@
 package linux
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -38,12 +39,15 @@ type MemInfo struct {
 }
 
 // GetMemInfo returns basic memory information from the system.
-func GetMemInfo() (*MemInfo, error) {
+func GetMemInfo(ctx context.Context) (*MemInfo, error) {
 	filePath := filepath.Join(ProcFS, "meminfo")
 
 	memInfo := new(MemInfo)
 
-	err := utils.ForLinesInFile(filePath, func(line string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	err := utils.ForLinesInFileWithContext(ctxWithTimeout, filePath, func(line string) error {
 		var err error
 
 		fields := strings.Fields(line)

--- a/app/inventory/linux/process_status.go
+++ b/app/inventory/linux/process_status.go
@@ -19,6 +19,7 @@
 package linux
 
 import (
+	"context"
 	"fmt"
 	"os/user"
 	"path/filepath"
@@ -36,11 +37,14 @@ type ProcessStatus struct {
 
 // GetProcessStatus returns ProcessStatus based on /proc/*/status.
 // See `man proc` -> `/proc/[pid]/status section for details on the file format.
-func GetProcessStatus(pid string) (*ProcessStatus, error) {
+func GetProcessStatus(ctx context.Context, pid string) (*ProcessStatus, error) {
 	statusFilePath := filepath.Join(ProcFS, pid, "status")
 	processStatus := new(ProcessStatus)
 
-	err := utils.ForLinesInFile(statusFilePath, func(line string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	err := utils.ForLinesInFileWithContext(ctxWithTimeout, statusFilePath, func(line string) error {
 		fields := strings.Fields(line)
 
 		switch fields[0] {

--- a/app/inventory/linux/running_processes.go
+++ b/app/inventory/linux/running_processes.go
@@ -75,7 +75,7 @@ func GetProcessCommand(pid string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
 	defer cancel()
 
-	cmdLineBytes, err := utils.ReadFileContext(ctx, cmdLinePath)
+	cmdLineBytes, err := utils.ReadFileWithContext(ctx, cmdLinePath)
 	if err != nil {
 		return "", fmt.Errorf("error reading %s: %w", cmdLinePath, err)
 	}

--- a/app/inventory/linux/running_processes.go
+++ b/app/inventory/linux/running_processes.go
@@ -28,8 +28,12 @@ import (
 )
 
 // ListRunningProcesses returns a list of PIDs of currently running processes.
-func ListRunningProcesses() ([]string, error) {
-	dirNames, err := utils.ListDirectory(ProcFS)
+func ListRunningProcesses(ctx context.Context) ([]string, error) {
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	dirNames, err := utils.ListDirectoryWithContext(ctxWithTimeout, ProcFS)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +52,8 @@ func ListRunningProcesses() ([]string, error) {
 }
 
 // ListRunningProcessesNames returns a map of running process PID -> process command-line.
-func ListRunningProcessesNames() (map[string]string, error) {
-	runningProcesses, err := ListRunningProcesses()
+func ListRunningProcessesNames(ctx context.Context) (map[string]string, error) {
+	runningProcesses, err := ListRunningProcesses(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +63,7 @@ func ListRunningProcessesNames() (map[string]string, error) {
 	for _, pid := range runningProcesses {
 		var cmdLine string
 
-		if cmdLine, err = GetProcessCommand(pid); err != nil {
+		if cmdLine, err = GetProcessCommand(ctx, pid); err != nil {
 			return nil, err
 		}
 
@@ -70,12 +74,12 @@ func ListRunningProcessesNames() (map[string]string, error) {
 }
 
 // GetProcessCommand returns a command used to start the process.
-func GetProcessCommand(pid string) (string, error) {
+func GetProcessCommand(ctx context.Context, pid string) (string, error) {
 	cmdLinePath := filepath.Join(ProcFS, pid, "cmdline")
-	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
 	defer cancel()
 
-	cmdLineBytes, err := utils.ReadFileWithContext(ctx, cmdLinePath)
+	cmdLineBytes, err := utils.ReadFileWithContext(ctxWithTimeout, cmdLinePath)
 	if err != nil {
 		return "", fmt.Errorf("error reading %s: %w", cmdLinePath, err)
 	}

--- a/app/inventory/linux/running_processes.go
+++ b/app/inventory/linux/running_processes.go
@@ -19,8 +19,8 @@
 package linux
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -72,8 +72,10 @@ func ListRunningProcessesNames() (map[string]string, error) {
 // GetProcessCommand returns a command used to start the process.
 func GetProcessCommand(pid string) (string, error) {
 	cmdLinePath := filepath.Join(ProcFS, pid, "cmdline")
+	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	defer cancel()
 
-	cmdLineBytes, err := os.ReadFile(cmdLinePath)
+	cmdLineBytes, err := utils.ReadFileContext(ctx, cmdLinePath)
 	if err != nil {
 		return "", fmt.Errorf("error reading %s: %w", cmdLinePath, err)
 	}

--- a/app/inventory/ports_linux.go
+++ b/app/inventory/ports_linux.go
@@ -19,6 +19,7 @@
 package inventory
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -36,19 +37,19 @@ import (
 )
 
 // CollectPortsInventory returns populated Ports inventory based on current system status.
-func CollectPortsInventory() (*Ports, error) {
+func CollectPortsInventory(ctx context.Context) (*Ports, error) {
 	ports := new(Ports)
 
 	var protocols = []string{"tcp", "tcp6", "udp", "udp6"}
 
-	inodesMap, err := loadProcessFDInodes()
+	inodesMap, err := loadProcessFDInodes(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, protocol := range protocols {
 		var listeningPorts []Port
-		if listeningPorts, err = parseNetworkPorts(protocol, inodesMap); err != nil {
+		if listeningPorts, err = parseNetworkPorts(ctx, protocol, inodesMap); err != nil {
 			return nil, err
 		}
 
@@ -61,9 +62,9 @@ func CollectPortsInventory() (*Ports, error) {
 }
 
 // loadProcessFDInodes loads mapping of processes' open files inodes to file paths.
-func loadProcessFDInodes() (map[uint64]string, error) {
+func loadProcessFDInodes(ctx context.Context) (map[uint64]string, error) {
 	// scan all open files for all running processes
-	runningProcesses, err := linux.ListRunningProcesses()
+	runningProcesses, err := linux.ListRunningProcesses(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot list currently running processes: %w", err)
 	}
@@ -79,7 +80,10 @@ func loadProcessFDInodes() (map[uint64]string, error) {
 		processProcPath := filepath.Join(linux.ProcFS, pid)
 		fdDirPath := filepath.Join(processProcPath, "fd")
 
-		fdPaths, err = utils.ListDirectory(fdDirPath)
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+		defer cancel()
+
+		fdPaths, err = utils.ListDirectoryWithContext(ctxWithTimeout, fdDirPath)
 		if err != nil {
 			log.Debugf("cannot list inodes for process %s: %v", pid, err)
 			continue
@@ -109,11 +113,14 @@ func loadProcessFDInodes() (map[uint64]string, error) {
 }
 
 // parseNetworkPorts parses /proc/net/<protocol> file format and returns a list of listening ports.
-func parseNetworkPorts(protocol string, inodesMap map[uint64]string) ([]Port, error) {
+func parseNetworkPorts(ctx context.Context, protocol string, inodesMap map[uint64]string) ([]Port, error) {
 	procFilePath := filepath.Join("/proc/net", protocol)
 	ports := make([]Port, 0)
 
-	err := utils.ForLinesInFile(procFilePath, func(line string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	err := utils.ForLinesInFileWithContext(ctxWithTimeout, procFilePath, func(line string) error {
 		fields := strings.Fields(line)
 
 		// Skip non-listening sockets (that also skips the header).
@@ -139,7 +146,7 @@ func parseNetworkPorts(protocol string, inodesMap map[uint64]string) ([]Port, er
 		if fileDescriptorPath, found := inodesMap[uint64(inodeInt)]; found {
 			processID := strings.SplitN(fileDescriptorPath, "/", 4)[2]
 
-			if cmdLine, err = linux.GetProcessCommand(processID); err != nil {
+			if cmdLine, err = linux.GetProcessCommand(ctx, processID); err != nil {
 				return err
 			}
 		}

--- a/app/inventory/ports_linux.go
+++ b/app/inventory/ports_linux.go
@@ -93,7 +93,7 @@ func loadProcessFDInodes(ctx context.Context) (map[uint64]string, error) {
 			fdPath := filepath.Join(fdDirPath, relativeFDPath)
 
 			// get file info for each open file
-			if fileStat, err = os.Stat(fdPath); err != nil {
+			if fileStat, err = utils.StatWithContext(ctxWithTimeout, fdPath); err != nil {
 				// Silence debug messages for the agent PID, since it's always producing an error.
 				// The error is due to the agent closing the directory's file description (in utils.ListDirectory)
 				// before we get to read all the files' inodes.

--- a/app/inventory/ports_linux_test.go
+++ b/app/inventory/ports_linux_test.go
@@ -20,6 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"go.qbee.io/agent/app/utils"
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func TestCollectPortsInventory(t *testing.T) {
@@ -31,4 +34,7 @@ func TestCollectPortsInventory(t *testing.T) {
 	data, _ := json.MarshalIndent(ports, " ", " ")
 
 	fmt.Println(string(data))
+
+	// make sure that the goroutine count is back to its original value before collection
+	assert.Equal(t, utils.GetGoroutineCount(), int64(0))
 }

--- a/app/inventory/ports_linux_test.go
+++ b/app/inventory/ports_linux_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestCollectPortsInventory(t *testing.T) {
-	ports, err := CollectPortsInventory()
+	ports, err := CollectPortsInventory(t.Context())
 	if err != nil {
 		t.Fatalf("error collecting ports: %v", err)
 	}

--- a/app/inventory/processes_linux.go
+++ b/app/inventory/processes_linux.go
@@ -36,8 +36,8 @@ import (
 
 // CollectProcessesInventory returns populated Processes inventory based on current system status.
 // Based on https://www.kernel.org/doc/html/latest/filesystems/proc.html#id10
-func CollectProcessesInventory() (*Processes, error) {
-	runningProcesses, err := linux.ListRunningProcesses()
+func CollectProcessesInventory(ctx context.Context) (*Processes, error) {
+	runningProcesses, err := linux.ListRunningProcesses(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error listing running processes: %w", err)
 	}
@@ -48,12 +48,12 @@ func CollectProcessesInventory() (*Processes, error) {
 	firstReadTime := time.Now()
 
 	// collect total CPU jiffies
-	if totalJiffiesT0, err = getTotalJiffies(); err != nil {
+	if totalJiffiesT0, err = getTotalJiffies(ctx); err != nil {
 		return nil, err
 	}
 
 	// collect CPU stats for each process
-	if processJiffiesT0, err = getProcessStats(runningProcesses); err != nil {
+	if processJiffiesT0, err = getProcessStats(ctx, runningProcesses); err != nil {
 		return nil, err
 	}
 
@@ -63,18 +63,18 @@ func CollectProcessesInventory() (*Processes, error) {
 	time.Sleep(time.Second - time.Since(firstReadTime))
 
 	// collect total CPU jiffies (again)
-	if totalJiffiesT1, err = getTotalJiffies(); err != nil {
+	if totalJiffiesT1, err = getTotalJiffies(ctx); err != nil {
 		return nil, err
 	}
 
 	// collect CPU stats for each process (again)
-	if processJiffiesT1, err = getProcessStats(runningProcesses); err != nil {
+	if processJiffiesT1, err = getProcessStats(ctx, runningProcesses); err != nil {
 		return nil, err
 	}
 
 	// get system memory information
 	var memInfo *linux.MemInfo
-	if memInfo, err = linux.GetMemInfo(); err != nil {
+	if memInfo, err = linux.GetMemInfo(ctx); err != nil {
 		return nil, err
 	}
 
@@ -105,7 +105,7 @@ func CollectProcessesInventory() (*Processes, error) {
 		jiffiesDelta := jiffiesT1 - jiffiesT0
 
 		// get process status
-		if processStatus, err = linux.GetProcessStatus(pid); err != nil {
+		if processStatus, err = linux.GetProcessStatus(ctx, pid); err != nil {
 			// if process is gone, skip it
 			if errors.Is(err, fs.ErrNotExist) {
 				continue
@@ -131,18 +131,18 @@ func CollectProcessesInventory() (*Processes, error) {
 const procStatBufferSize = 1024
 
 // getProcessStats returns a map of PID -> process stats for currently running processes.
-func getProcessStats(runningProcesses []string) (map[string]linux.ProcessStats, error) {
+func getProcessStats(ctx context.Context, runningProcesses []string) (map[string]linux.ProcessStats, error) {
 	processStats := make(map[string]linux.ProcessStats)
 
 	var err error
 	var statFilePath string
-	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
 	defer cancel()
 
 	for _, pid := range runningProcesses {
 		statFilePath = filepath.Join(linux.ProcFS, pid, "stat")
 
-		data, readErr := utils.ReadFileWithContext(ctx, statFilePath)
+		data, readErr := utils.ReadFileWithContext(ctxWithTimeout, statFilePath)
 		if readErr != nil {
 			err = readErr
 			if errors.Is(err, fs.ErrNotExist) {
@@ -162,12 +162,12 @@ func getProcessStats(runningProcesses []string) (map[string]linux.ProcessStats, 
 
 // getTotalJiffies returns a sum of all jiffies from /proc/stat
 // We could use C.sysconf(C._SC_CLK_TCK), but that would require CGO and that's not helping with portability.
-func getTotalJiffies() (uint64, error) {
+func getTotalJiffies(ctx context.Context) (uint64, error) {
 	filePath := filepath.Join(linux.ProcFS, "stat")
-	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
 	defer cancel()
 
-	buf, err := utils.ReadFileWithContext(ctx, filePath)
+	buf, err := utils.ReadFileWithContext(ctxWithTimeout, filePath)
 	if err != nil {
 		return 0, fmt.Errorf("error reading %s: %w", filePath, err)
 	}

--- a/app/inventory/processes_linux.go
+++ b/app/inventory/processes_linux.go
@@ -128,8 +128,6 @@ func CollectProcessesInventory(ctx context.Context) (*Processes, error) {
 	return processes, nil
 }
 
-const procStatBufferSize = 1024
-
 // getProcessStats returns a map of PID -> process stats for currently running processes.
 func getProcessStats(ctx context.Context, runningProcesses []string) (map[string]linux.ProcessStats, error) {
 	processStats := make(map[string]linux.ProcessStats)

--- a/app/inventory/processes_linux.go
+++ b/app/inventory/processes_linux.go
@@ -20,10 +20,10 @@ package inventory
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/utils"
 )
 
 // CollectProcessesInventory returns populated Processes inventory based on current system status.
@@ -133,17 +134,17 @@ const procStatBufferSize = 1024
 func getProcessStats(runningProcesses []string) (map[string]linux.ProcessStats, error) {
 	processStats := make(map[string]linux.ProcessStats)
 
-	var n int
 	var err error
-	var procStatFile *os.File
 	var statFilePath string
-
-	buf := make([]byte, procStatBufferSize)
+	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	defer cancel()
 
 	for _, pid := range runningProcesses {
 		statFilePath = filepath.Join(linux.ProcFS, pid, "stat")
 
-		if procStatFile, err = os.Open(statFilePath); err != nil {
+		data, readErr := utils.ReadFileContext(ctx, statFilePath)
+		if readErr != nil {
+			err = readErr
 			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
@@ -151,18 +152,7 @@ func getProcessStats(runningProcesses []string) (map[string]linux.ProcessStats, 
 			return nil, fmt.Errorf("error opening %s: %w", statFilePath, err)
 		}
 
-		// read file contents to a buffer
-		n, err = procStatFile.Read(buf)
-
-		// close the file
-		_ = procStatFile.Close()
-
-		// check for errors
-		if err != nil {
-			return nil, fmt.Errorf("error reading %s: %w", statFilePath, err)
-		}
-
-		if processStats[pid], err = linux.NewProcessStats(string(buf[0:n])); err != nil {
+		if processStats[pid], err = linux.NewProcessStats(string(data)); err != nil {
 			return nil, err
 		}
 	}
@@ -174,18 +164,12 @@ func getProcessStats(runningProcesses []string) (map[string]linux.ProcessStats, 
 // We could use C.sysconf(C._SC_CLK_TCK), but that would require CGO and that's not helping with portability.
 func getTotalJiffies() (uint64, error) {
 	filePath := filepath.Join(linux.ProcFS, "stat")
+	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	defer cancel()
 
-	file, err := os.Open(filePath)
+	buf, err := utils.ReadFileContext(ctx, filePath)
 	if err != nil {
 		return 0, fmt.Errorf("error reading %s: %w", filePath, err)
-	}
-
-	defer func() { _ = file.Close() }()
-
-	// we don't need to read the whole file, we only care about the first line
-	buf := make([]byte, 512)
-	if _, err = file.Read(buf); err != nil {
-		return 0, fmt.Errorf("error reading contents of %s: %w", filePath, err)
 	}
 
 	firstLine := string(buf[0:bytes.Index(buf, []byte("\n"))])

--- a/app/inventory/processes_linux.go
+++ b/app/inventory/processes_linux.go
@@ -60,7 +60,17 @@ func CollectProcessesInventory(ctx context.Context) (*Processes, error) {
 	// Because CPU utilization can be calculated only over time,
 	// we need to wait a bit and collect another set of stats.
 	// The wait time is adjusted by how long it took to process the first batch of jiffies.
-	time.Sleep(time.Second - time.Since(firstReadTime))
+	wait := time.Second - time.Since(firstReadTime)
+	if wait > 0 {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
 
 	// collect total CPU jiffies (again)
 	if totalJiffiesT1, err = getTotalJiffies(ctx); err != nil {

--- a/app/inventory/processes_linux.go
+++ b/app/inventory/processes_linux.go
@@ -133,14 +133,13 @@ func getProcessStats(ctx context.Context, runningProcesses []string) (map[string
 	processStats := make(map[string]linux.ProcessStats)
 
 	var err error
-	var statFilePath string
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
-	defer cancel()
 
 	for _, pid := range runningProcesses {
-		statFilePath = filepath.Join(linux.ProcFS, pid, "stat")
+		statFilePath := filepath.Join(linux.ProcFS, pid, "stat")
 
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
 		data, readErr := utils.ReadFileWithContext(ctxWithTimeout, statFilePath)
+		cancel()
 		if readErr != nil {
 			err = readErr
 			if errors.Is(err, fs.ErrNotExist) {

--- a/app/inventory/processes_linux.go
+++ b/app/inventory/processes_linux.go
@@ -142,7 +142,7 @@ func getProcessStats(runningProcesses []string) (map[string]linux.ProcessStats, 
 	for _, pid := range runningProcesses {
 		statFilePath = filepath.Join(linux.ProcFS, pid, "stat")
 
-		data, readErr := utils.ReadFileContext(ctx, statFilePath)
+		data, readErr := utils.ReadFileWithContext(ctx, statFilePath)
 		if readErr != nil {
 			err = readErr
 			if errors.Is(err, fs.ErrNotExist) {
@@ -167,7 +167,7 @@ func getTotalJiffies() (uint64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
 	defer cancel()
 
-	buf, err := utils.ReadFileContext(ctx, filePath)
+	buf, err := utils.ReadFileWithContext(ctx, filePath)
 	if err != nil {
 		return 0, fmt.Errorf("error reading %s: %w", filePath, err)
 	}

--- a/app/inventory/processes_linux_test.go
+++ b/app/inventory/processes_linux_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestCollectProcessesInventory(t *testing.T) {
-	processes, err := CollectProcessesInventory()
+	processes, err := CollectProcessesInventory(t.Context())
 	if err != nil {
 		t.Fatalf("error collecting processes: %v", err)
 	}

--- a/app/inventory/processes_linux_test.go
+++ b/app/inventory/processes_linux_test.go
@@ -18,6 +18,7 @@ package inventory
 import (
 	"testing"
 
+	"go.qbee.io/agent/app/utils"
 	"go.qbee.io/agent/app/utils/assert"
 )
 
@@ -36,4 +37,7 @@ func TestCollectProcessesInventory(t *testing.T) {
 		assert.NotEmpty(t, process.User)
 		assert.NotEmpty(t, process.Command)
 	}
+
+	// make sure that the goroutine count is back to its original value before collection
+	assert.Equal(t, utils.GetGoroutineCount(), int64(0))
 }

--- a/app/inventory/system_linux.go
+++ b/app/inventory/system_linux.go
@@ -19,6 +19,7 @@
 package inventory
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -42,7 +43,7 @@ const (
 )
 
 // CollectSystemInventory returns populated System inventory based on current system status.
-func CollectSystemInventory(tpmEnabled bool) (*System, error) {
+func CollectSystemInventory(ctx context.Context, tpmEnabled bool) (*System, error) {
 
 	if cachedItem, ok := cache.Get(systemInventoryCacheKey); ok {
 		return cachedItem.(*System), nil
@@ -60,7 +61,7 @@ func CollectSystemInventory(tpmEnabled bool) (*System, error) {
 		return nil, err
 	}
 
-	if err := systemInfo.parseCPUInfo(); err != nil {
+	if err := systemInfo.parseCPUInfo(ctx); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +73,7 @@ func CollectSystemInventory(tpmEnabled bool) (*System, error) {
 		return nil, err
 	}
 
-	if err := systemInfo.gatherNetworkInfo(); err != nil {
+	if err := systemInfo.gatherNetworkInfo(ctx); err != nil {
 		return nil, err
 	}
 
@@ -93,12 +94,15 @@ func CollectSystemInventory(tpmEnabled bool) (*System, error) {
 }
 
 // getDefaultNetworkInterface returns a default network interface name.
-func (systemInfo *SystemInfo) getDefaultNetworkInterface() (string, error) {
+func (systemInfo *SystemInfo) getDefaultNetworkInterface(ctx context.Context) (string, error) {
 	routeFilePath := filepath.Join(linux.ProcFS, "net", "route")
 
 	defaultInterface := ""
 
-	err := utils.ForLinesInFile(routeFilePath, func(line string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	err := utils.ForLinesInFileWithContext(ctxWithTimeout, routeFilePath, func(line string) error {
 		fields := strings.Fields(line)
 		if fields[1] == "Destination" {
 			return nil
@@ -122,8 +126,8 @@ func (systemInfo *SystemInfo) getDefaultNetworkInterface() (string, error) {
 }
 
 // gatherNetworkInfo gathers system's networking configuration.
-func (systemInfo *SystemInfo) gatherNetworkInfo() error {
-	defaultNetworkInterface, err := systemInfo.getDefaultNetworkInterface()
+func (systemInfo *SystemInfo) gatherNetworkInfo(ctx context.Context) error {
+	defaultNetworkInterface, err := systemInfo.getDefaultNetworkInterface(ctx)
 	if err != nil {
 		return err
 	}
@@ -234,12 +238,15 @@ func (systemInfo *SystemInfo) parseOSRelease() error {
 }
 
 // parseCPUInfo parses /proc/cpuinfo for extra details re. CPU.
-func (systemInfo *SystemInfo) parseCPUInfo() error {
+func (systemInfo *SystemInfo) parseCPUInfo(ctx context.Context) error {
 	filePath := filepath.Join(linux.ProcFS, "cpuinfo")
 
 	const expectedLineSubstrings = 2
 
-	return utils.ForLinesInFile(filePath, func(line string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	return utils.ForLinesInFileWithContext(ctxWithTimeout, filePath, func(line string) error {
 		line = strings.TrimSpace(line)
 
 		substrings := strings.SplitN(line, ":", expectedLineSubstrings)

--- a/app/inventory/system_linux_test.go
+++ b/app/inventory/system_linux_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestCollectSystemInventory(t *testing.T) {
 
-	systemInfo, err := inventory.CollectSystemInventory(true)
+	systemInfo, err := inventory.CollectSystemInventory(t.Context(), true)
 	if err != nil {
 		t.Fatalf("error collecting system info: %v", err)
 	}

--- a/app/inventory/system_linux_test.go
+++ b/app/inventory/system_linux_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"go.qbee.io/agent/app/inventory"
+	"go.qbee.io/agent/app/utils"
 	"go.qbee.io/agent/app/utils/assert"
 )
 
@@ -40,4 +41,7 @@ func TestCollectSystemInventory(t *testing.T) {
 	assert.NotEmpty(t, systemInfo.System.Host)
 	assert.NotEmpty(t, systemInfo.System.Architecture)
 	assert.NotEmpty(t, systemInfo.System.OSVersion)
+
+	// make sure that the goroutine count is back to its original value before collection
+	assert.Equal(t, utils.GetGoroutineCount(), int64(0))
 }

--- a/app/metrics/cpu.go
+++ b/app/metrics/cpu.go
@@ -48,12 +48,12 @@ type CPUValues struct {
 }
 
 // CollectCPU returns CPU metrics.
-func CollectCPU() (*CPUValues, error) {
+func CollectCPU(ctx context.Context) (*CPUValues, error) {
 	filePath := filepath.Join(linux.ProcFS, "stat")
-	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
 	defer cancel()
 
-	buf, err := utils.ReadFileContext(ctx, filePath)
+	buf, err := utils.ReadFileWithContext(ctxWithTimeout, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", filePath, err)
 	}

--- a/app/metrics/cpu.go
+++ b/app/metrics/cpu.go
@@ -18,14 +18,15 @@ package metrics
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/utils"
 )
 
 // CPUValues contains CPU metrics.
@@ -49,18 +50,12 @@ type CPUValues struct {
 // CollectCPU returns CPU metrics.
 func CollectCPU() (*CPUValues, error) {
 	filePath := filepath.Join(linux.ProcFS, "stat")
+	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	defer cancel()
 
-	file, err := os.Open(filePath)
+	buf, err := utils.ReadFileContext(ctx, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", filePath, err)
-	}
-
-	defer func() { _ = file.Close() }()
-
-	// we don't need to read the whole file, we only care about the first line
-	buf := make([]byte, 512)
-	if _, err = file.Read(buf); err != nil {
-		return nil, fmt.Errorf("error reading contents of %s: %w", filePath, err)
 	}
 
 	firstLine := string(buf[0:bytes.Index(buf, []byte("\n"))])

--- a/app/metrics/cpu.go
+++ b/app/metrics/cpu.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"math"
 	"path/filepath"
 	"strconv"
@@ -54,20 +53,12 @@ func CollectCPU(ctx context.Context) (*CPUValues, error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
 	defer cancel()
 
-	file, err := utils.OpenFileWithContext(ctxWithTimeout, filePath)
+	data, err := utils.ReadFileWithContext(ctxWithTimeout, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", filePath, err)
 	}
 
-	defer func() { _ = file.(io.Closer).Close() }()
-
-	// we don't need to read the whole file, we only care about the first line
-	buf := make([]byte, 512)
-	if _, err = file.Read(buf); err != nil {
-		return nil, fmt.Errorf("error reading contents of %s: %w", filePath, err)
-	}
-
-	firstLine := string(buf[0:bytes.Index(buf, []byte("\n"))])
+	firstLine := string(data[0:bytes.Index(data, []byte("\n"))])
 	lineFields := strings.Fields(firstLine)
 
 	fields := []string{"user", "nice", "system", "idle", "iowait", "irq"}

--- a/app/metrics/cpu.go
+++ b/app/metrics/cpu.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"path/filepath"
 	"strconv"
@@ -53,9 +54,17 @@ func CollectCPU(ctx context.Context) (*CPUValues, error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
 	defer cancel()
 
-	buf, err := utils.ReadFileWithContext(ctxWithTimeout, filePath)
+	file, err := utils.OpenFileWithContext(ctxWithTimeout, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", filePath, err)
+	}
+
+	defer func() { _ = file.(io.Closer).Close() }()
+
+	// we don't need to read the whole file, we only care about the first line
+	buf := make([]byte, 512)
+	if _, err = file.Read(buf); err != nil {
+		return nil, fmt.Errorf("error reading contents of %s: %w", filePath, err)
 	}
 
 	firstLine := string(buf[0:bytes.Index(buf, []byte("\n"))])

--- a/app/metrics/cpu_test.go
+++ b/app/metrics/cpu_test.go
@@ -22,14 +22,14 @@ import (
 )
 
 func TestCollectCPU(t *testing.T) {
-	v, err := CollectCPU()
+	v, err := CollectCPU(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error = %v", err)
 	}
 
 	time.Sleep(1 * time.Second)
 
-	v2, err := CollectCPU()
+	v2, err := CollectCPU(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error = %v", err)
 	}

--- a/app/metrics/filesystem.go
+++ b/app/metrics/filesystem.go
@@ -17,6 +17,7 @@
 package metrics
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -42,8 +43,8 @@ type FilesystemValues struct {
 const fsBlockSize = 1024
 
 // CollectFilesystem returns filesystem metric for each filesystem mounted in read-write mode.
-func CollectFilesystem() ([]Metric, error) {
-	mounts, err := getFilesystemMounts()
+func CollectFilesystem(ctx context.Context) ([]Metric, error) {
+	mounts, err := getFilesystemMounts(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -83,17 +84,18 @@ func CollectFilesystem() ([]Metric, error) {
 }
 
 // getFilesystemMounts returns a list of block-device mount points.
-func getFilesystemMounts() ([]string, error) {
-	supportedFilesystems, err := getSupportedFilesystems()
+func getFilesystemMounts(ctx context.Context) ([]string, error) {
+	supportedFilesystems, err := getSupportedFilesystems(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	path := filepath.Join(linux.ProcFS, "mounts")
-
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
 	mounts := make([]string, 0)
 
-	err = utils.ForLinesInFile(path, func(line string) error {
+	err = utils.ForLinesInFileWithContext(ctxWithTimeout, path, func(line string) error {
 		fields := strings.Fields(line)
 
 		if fields[3] != "rw" && !strings.HasPrefix(fields[3], "rw,") {
@@ -114,12 +116,16 @@ func getFilesystemMounts() ([]string, error) {
 }
 
 // getSupportedFilesystems returns a map of supported block-device filesystems.
-func getSupportedFilesystems() (map[string]bool, error) {
+func getSupportedFilesystems(ctx context.Context) (map[string]bool, error) {
+
 	path := filepath.Join(linux.ProcFS, "filesystems")
 
 	filesystems := make(map[string]bool)
 
-	err := utils.ForLinesInFile(path, func(line string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	err := utils.ForLinesInFileWithContext(ctxWithTimeout, path, func(line string) error {
 		if strings.HasPrefix(line, "nodev") {
 			return nil
 		}

--- a/app/metrics/filesystem_test.go
+++ b/app/metrics/filesystem_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestCollectFilesystem(t *testing.T) {
-	gotMetrics, err := CollectFilesystem()
+	gotMetrics, err := CollectFilesystem(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error = %v", err)
 	}

--- a/app/metrics/loadavg.go
+++ b/app/metrics/loadavg.go
@@ -49,12 +49,12 @@ type LoadAverageValues struct {
 }
 
 // CollectLoadAverage metrics.
-func CollectLoadAverage() ([]Metric, error) {
+func CollectLoadAverage(ctx context.Context) ([]Metric, error) {
 	path := filepath.Join(linux.ProcFS, "loadavg")
-	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
 	defer cancel()
 
-	data, err := utils.ReadFileContext(ctx, path)
+	data, err := utils.ReadFileWithContext(ctxWithTimeout, path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", path, err)
 	}

--- a/app/metrics/loadavg.go
+++ b/app/metrics/loadavg.go
@@ -17,14 +17,15 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/utils"
 )
 
 // LoadAverageValues contains load average metrics.
@@ -50,8 +51,10 @@ type LoadAverageValues struct {
 // CollectLoadAverage metrics.
 func CollectLoadAverage() ([]Metric, error) {
 	path := filepath.Join(linux.ProcFS, "loadavg")
+	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	defer cancel()
 
-	data, err := os.ReadFile(path)
+	data, err := utils.ReadFileContext(ctx, path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", path, err)
 	}

--- a/app/metrics/loadavg_test.go
+++ b/app/metrics/loadavg_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCollectLoadAverage(t *testing.T) {
-	gotMetrics, err := CollectLoadAverage()
+	gotMetrics, err := CollectLoadAverage(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/app/metrics/memory.go
+++ b/app/metrics/memory.go
@@ -17,6 +17,7 @@
 package metrics
 
 import (
+	"context"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -47,12 +48,14 @@ type MemoryValues struct {
 }
 
 // CollectMemory metrics.
-func CollectMemory() ([]Metric, error) {
+func CollectMemory(ctx context.Context) ([]Metric, error) {
 	path := filepath.Join(linux.ProcFS, "meminfo")
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
 
 	values := new(MemoryValues)
 
-	err := utils.ForLinesInFile(path, func(line string) error {
+	err := utils.ForLinesInFileWithContext(ctxWithTimeout, path, func(line string) error {
 		fields := strings.Fields(line)
 		if len(fields) != 3 {
 			return nil

--- a/app/metrics/memory_test.go
+++ b/app/metrics/memory_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCollectMemory(t *testing.T) {
-	gotMetrics, err := CollectMemory()
+	gotMetrics, err := CollectMemory(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/app/metrics/network.go
+++ b/app/metrics/network.go
@@ -17,6 +17,7 @@
 package metrics
 
 import (
+	"context"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -49,12 +50,15 @@ type NetworkValues struct {
 // CollectNetwork metrics.
 // Note: collected are total values. The agent must report delta,
 // so we need to keep state from the last report and subtract it before delivery.
-func CollectNetwork() ([]Metric, error) {
+func CollectNetwork(ctx context.Context) ([]Metric, error) {
 	path := filepath.Join(linux.ProcFS, "net", "dev")
 
 	metrics := make([]Metric, 0)
 
-	err := utils.ForLinesInFile(path, func(line string) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	err := utils.ForLinesInFileWithContext(ctxWithTimeout, path, func(line string) error {
 		fields := strings.Fields(line)
 
 		if !strings.HasSuffix(fields[0], ":") {

--- a/app/metrics/network_test.go
+++ b/app/metrics/network_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCollectNetwork(t *testing.T) {
-	v1, err := CollectNetwork()
+	v1, err := CollectNetwork(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestCollectNetwork(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	v2, err := CollectNetwork()
+	v2, err := CollectNetwork(t.Context())
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/app/metrics/service.go
+++ b/app/metrics/service.go
@@ -17,6 +17,7 @@
 package metrics
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -43,7 +44,7 @@ func New(apiClient *api.Client) *Service {
 
 type metricsCollector struct {
 	name string
-	fn   func() ([]Metric, error)
+	fn   func(ctx context.Context) ([]Metric, error)
 }
 
 var metricsCollectors = []metricsCollector{
@@ -71,7 +72,7 @@ var metricsCacheTTL = 60 * time.Second
 
 // Collect system metrics.
 // If any errors are encountered, they'll be logged, but won't interrupt the process.
-func (s *Service) Collect() []Metric {
+func (s *Service) Collect(ctx context.Context) []Metric {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -83,7 +84,7 @@ func (s *Service) Collect() []Metric {
 
 	// collect metrics which don't depend on state
 	for _, collector := range metricsCollectors {
-		if metrics, err := collector.fn(); err != nil {
+		if metrics, err := collector.fn(ctx); err != nil {
 			log.Errorf("%s metrics error: %v", collector.name, err)
 		} else {
 			allMetrics = append(allMetrics, metrics...)
@@ -91,13 +92,13 @@ func (s *Service) Collect() []Metric {
 	}
 
 	// collect metrics which require previous state to produce delta-metrics
-	if cpuMetric, err := s.doCollectCPU(); err != nil {
+	if cpuMetric, err := s.doCollectCPU(ctx); err != nil {
 		log.Errorf("cpu metrics error: %v", err)
 	} else if cpuMetric != nil {
 		allMetrics = append(allMetrics, *cpuMetric)
 	}
 
-	if networkMetrics, err := s.doCollectNetwork(); err != nil {
+	if networkMetrics, err := s.doCollectNetwork(ctx); err != nil {
 		log.Errorf("network metrics error: %v", err)
 	} else if networkMetrics != nil {
 		allMetrics = append(allMetrics, networkMetrics...)
@@ -108,9 +109,9 @@ func (s *Service) Collect() []Metric {
 	return allMetrics
 }
 
-func (s *Service) doCollectCPU() (*Metric, error) {
+func (s *Service) doCollectCPU(ctx context.Context) (*Metric, error) {
 
-	cpuValues, err := CollectCPU()
+	cpuValues, err := CollectCPU(ctx)
 
 	if err != nil {
 		return nil, err
@@ -139,9 +140,9 @@ func (s *Service) doCollectCPU() (*Metric, error) {
 	}, nil
 }
 
-func (s *Service) doCollectNetwork() ([]Metric, error) {
+func (s *Service) doCollectNetwork(ctx context.Context) ([]Metric, error) {
 
-	networkValues, err := CollectNetwork()
+	networkValues, err := CollectNetwork(ctx)
 
 	if err != nil {
 		return nil, err

--- a/app/metrics/service.go
+++ b/app/metrics/service.go
@@ -84,18 +84,10 @@ func (s *Service) Collect(ctx context.Context) []Metric {
 
 	// collect metrics which don't depend on state
 	for _, collector := range metricsCollectors {
-		if err := ctx.Err(); err != nil {
-			return allMetrics
-		}
-
 		if metrics, err := collector.fn(ctx); err != nil {
 			log.Errorf("%s metrics error: %v", collector.name, err)
 		} else {
 			allMetrics = append(allMetrics, metrics...)
-		}
-
-		if err := ctx.Err(); err != nil {
-			return allMetrics
 		}
 	}
 
@@ -104,10 +96,6 @@ func (s *Service) Collect(ctx context.Context) []Metric {
 		log.Errorf("cpu metrics error: %v", err)
 	} else if cpuMetric != nil {
 		allMetrics = append(allMetrics, *cpuMetric)
-	}
-
-	if err := ctx.Err(); err != nil {
-		return allMetrics
 	}
 
 	if networkMetrics, err := s.doCollectNetwork(ctx); err != nil {

--- a/app/metrics/service.go
+++ b/app/metrics/service.go
@@ -84,10 +84,18 @@ func (s *Service) Collect(ctx context.Context) []Metric {
 
 	// collect metrics which don't depend on state
 	for _, collector := range metricsCollectors {
+		if err := ctx.Err(); err != nil {
+			return allMetrics
+		}
+
 		if metrics, err := collector.fn(ctx); err != nil {
 			log.Errorf("%s metrics error: %v", collector.name, err)
 		} else {
 			allMetrics = append(allMetrics, metrics...)
+		}
+
+		if err := ctx.Err(); err != nil {
+			return allMetrics
 		}
 	}
 
@@ -96,6 +104,10 @@ func (s *Service) Collect(ctx context.Context) []Metric {
 		log.Errorf("cpu metrics error: %v", err)
 	} else if cpuMetric != nil {
 		allMetrics = append(allMetrics, *cpuMetric)
+	}
+
+	if err := ctx.Err(); err != nil {
+		return allMetrics
 	}
 
 	if networkMetrics, err := s.doCollectNetwork(ctx); err != nil {

--- a/app/metrics/service_test.go
+++ b/app/metrics/service_test.go
@@ -30,7 +30,7 @@ func TestCollectServiceCollectAll(t *testing.T) {
 
 	srv := New(apiClient)
 
-	gotMetrics := srv.Collect()
+	gotMetrics := srv.Collect(t.Context())
 
 	if len(gotMetrics) == 0 {
 		t.Fatalf("expected at least one metric, got 0")
@@ -46,7 +46,7 @@ func TestCollectServiceCollectAll(t *testing.T) {
 	// Sleep to get deltas
 	time.Sleep(1 * time.Second)
 
-	gotMetrics = srv.Collect()
+	gotMetrics = srv.Collect(t.Context())
 	metricBytes, err = json.MarshalIndent(gotMetrics, "", "  ")
 
 	if err != nil {

--- a/app/metrics/service_test.go
+++ b/app/metrics/service_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/utils"
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func TestCollectServiceCollectAll(t *testing.T) {
@@ -54,4 +56,11 @@ func TestCollectServiceCollectAll(t *testing.T) {
 	}
 
 	fmt.Printf("got metrics: %s", string(metricBytes))
+}
+
+func Test_GoroutineCountAfterAllMetrics(t *testing.T) {
+	apiClient, _ := api.NewMockedClient()
+	srv := New(apiClient)
+	srv.Collect(t.Context())
+	assert.Equal(t, utils.GetGoroutineCount(), int64(0))
 }

--- a/app/metrics/service_test.go
+++ b/app/metrics/service_test.go
@@ -17,14 +17,12 @@
 package metrics
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
 	"go.qbee.io/agent/app/api"
-	"go.qbee.io/agent/app/utils/cache"
 )
 
 func TestCollectServiceCollectAll(t *testing.T) {
@@ -56,36 +54,4 @@ func TestCollectServiceCollectAll(t *testing.T) {
 	}
 
 	fmt.Printf("got metrics: %s", string(metricBytes))
-}
-
-func TestCollectServiceStopsWhenContextIsCanceled(t *testing.T) {
-	cache.Delete(metricsCacheKey)
-	t.Cleanup(func() {
-		cache.Delete(metricsCacheKey)
-	})
-
-	collectors := metricsCollectors
-	t.Cleanup(func() {
-		metricsCollectors = collectors
-	})
-
-	called := false
-	metricsCollectors = []metricsCollector{{
-		name: "test",
-		fn: func(context.Context) ([]Metric, error) {
-			called = true
-			return nil, nil
-		},
-	}}
-
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	gotMetrics := New(nil).Collect(ctx)
-	if len(gotMetrics) != 0 {
-		t.Fatalf("expected no metrics, got %d", len(gotMetrics))
-	}
-	if called {
-		t.Fatal("collector was called after context cancellation")
-	}
 }

--- a/app/metrics/service_test.go
+++ b/app/metrics/service_test.go
@@ -17,12 +17,14 @@
 package metrics
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
 	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/utils/cache"
 )
 
 func TestCollectServiceCollectAll(t *testing.T) {
@@ -54,4 +56,36 @@ func TestCollectServiceCollectAll(t *testing.T) {
 	}
 
 	fmt.Printf("got metrics: %s", string(metricBytes))
+}
+
+func TestCollectServiceStopsWhenContextIsCanceled(t *testing.T) {
+	cache.Delete(metricsCacheKey)
+	t.Cleanup(func() {
+		cache.Delete(metricsCacheKey)
+	})
+
+	collectors := metricsCollectors
+	t.Cleanup(func() {
+		metricsCollectors = collectors
+	})
+
+	called := false
+	metricsCollectors = []metricsCollector{{
+		name: "test",
+		fn: func(context.Context) ([]Metric, error) {
+			called = true
+			return nil, nil
+		},
+	}}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	gotMetrics := New(nil).Collect(ctx)
+	if len(gotMetrics) != 0 {
+		t.Fatalf("expected no metrics, got %d", len(gotMetrics))
+	}
+	if called {
+		t.Fatal("collector was called after context cancellation")
+	}
 }

--- a/app/metrics/temperature.go
+++ b/app/metrics/temperature.go
@@ -17,8 +17,8 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -26,6 +26,7 @@ import (
 
 	"go.qbee.io/agent/app/inventory/linux"
 	"go.qbee.io/agent/app/log"
+	"go.qbee.io/agent/app/utils"
 )
 
 // TemperatureValues represents temperature metrics
@@ -105,7 +106,11 @@ func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
 		// Get the label of the temperature you are reading
 		label := ""
 
-		if raw, _ = os.ReadFile(basepath + "_label"); len(raw) != 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+		raw, _ = utils.ReadFileContext(ctx, basepath+"_label")
+		cancel()
+
+		if len(raw) != 0 {
 			// Format the label from "Core 0" to "core_0"
 			label = strings.Join(strings.Split(strings.TrimSpace(strings.ToLower(string(raw))), " "), "_")
 		}
@@ -164,7 +169,9 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 
 	for _, file := range files {
 		// Get the name of the temperature you are reading
-		rawName, err := os.ReadFile(filepath.Join(file, "type"))
+		ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+		rawName, err := utils.ReadFileContext(ctx, filepath.Join(file, "type"))
+		cancel()
 		if err != nil {
 			continue
 		}
@@ -202,7 +209,10 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 
 // parseTemperatureFile reads a temperature file and returns the temperature in degrees Celsius
 func parseTemperatureFile(file string) (float64, error) {
-	raw, err := os.ReadFile(file)
+	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	raw, err := utils.ReadFileContext(ctx, file)
 	if err != nil {
 		return 0, err
 	}

--- a/app/metrics/temperature.go
+++ b/app/metrics/temperature.go
@@ -47,18 +47,18 @@ type cpuTemperatures struct {
 const hostTemperatureScale = 1000.0
 
 // CollectTemperature collects temperature metrics from from /sys/class/[hwmon|thermal]
-func CollectTemperature() ([]Metric, error) {
+func CollectTemperature(ctx context.Context) ([]Metric, error) {
 
 	cpuTemps := new(cpuTemperatures)
 	var errString string
 
 	// Attempt to collect temperature metrics from hwmon
-	if err := cpuTemps.hwMonTemperatureMetrics(); err != nil {
+	if err := cpuTemps.hwMonTemperatureMetrics(ctx); err != nil {
 		errString += err.Error()
 	}
 
 	// Attempt to collect temperature metrics from thermal zone
-	if err := cpuTemps.thermalZoneTemperatureMetrics(); err != nil {
+	if err := cpuTemps.thermalZoneTemperatureMetrics(ctx); err != nil {
 		errString += err.Error()
 	}
 
@@ -83,9 +83,9 @@ func CollectTemperature() ([]Metric, error) {
 }
 
 // hwMonTemperatureMetrics collects temperature metrics from /sys/class/hwmon/hwmon*/temp*_input
-func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
+func (c *cpuTemperatures) hwMonTemperatureMetrics(ctx context.Context) error {
 
-	files, err := getHwMonFiles()
+	files, err := getHwMonFiles(ctx)
 	if err != nil {
 		return err
 	}
@@ -106,8 +106,8 @@ func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
 		// Get the label of the temperature you are reading
 		label := ""
 
-		ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
-		raw, _ = utils.ReadFileContext(ctx, basepath+"_label")
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+		raw, _ = utils.ReadFileWithContext(ctxWithTimeout, basepath+"_label")
 		cancel()
 
 		if len(raw) != 0 {
@@ -117,7 +117,7 @@ func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
 
 		// Some boards have a cpu_thermal zone
 		if strings.HasPrefix(label, "cpu_thermal") {
-			temperature, err = parseTemperatureFile(file)
+			temperature, err = parseTemperatureFile(ctx, file)
 			if err != nil {
 				continue
 			}
@@ -126,7 +126,7 @@ func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
 
 		// Capture all core temperatures
 		if strings.HasPrefix(label, "core") {
-			temperature, err = parseTemperatureFile(file)
+			temperature, err = parseTemperatureFile(ctx, file)
 			if err != nil {
 				continue
 			}
@@ -135,7 +135,7 @@ func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
 
 		// Capture all socket temperatures
 		if strings.Contains(label, "package") || strings.Contains(label, "physical") || label == "tccd1" {
-			temperature, err = parseTemperatureFile(file)
+			temperature, err = parseTemperatureFile(ctx, file)
 			if err != nil {
 				continue
 			}
@@ -156,9 +156,9 @@ func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
 }
 
 // thermalZoneTemperatureMetrics collects temperature metrics from /sys/class/thermal/thermal_zone*/temp
-func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
+func (c *cpuTemperatures) thermalZoneTemperatureMetrics(ctx context.Context) error {
 
-	files, err := getThermalZoneFiles()
+	files, err := getThermalZoneFiles(ctx)
 	if err != nil {
 		return err
 	}
@@ -169,8 +169,8 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 
 	for _, file := range files {
 		// Get the name of the temperature you are reading
-		ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
-		rawName, err := utils.ReadFileContext(ctx, filepath.Join(file, "type"))
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+		rawName, err := utils.ReadFileWithContext(ctxWithTimeout, filepath.Join(file, "type"))
 		cancel()
 		if err != nil {
 			continue
@@ -180,7 +180,7 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 
 		// Some boards have acpi_thermal zones
 		if strings.HasPrefix(name, "acpi") {
-			acpiTemp, err := parseTemperatureFile(filepath.Join(file, "temp"))
+			acpiTemp, err := parseTemperatureFile(ctx, filepath.Join(file, "temp"))
 			if err != nil {
 				continue
 			}
@@ -189,7 +189,7 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 
 		// Some boards have a pch_thermal zone
 		if strings.HasPrefix(name, "pch") {
-			chipsetTemp, err := parseTemperatureFile(filepath.Join(file, "temp"))
+			chipsetTemp, err := parseTemperatureFile(ctx, filepath.Join(file, "temp"))
 			if err != nil {
 				continue
 			}
@@ -197,7 +197,7 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 		}
 		// ARM based boards have cpu-thermal zones
 		if strings.HasPrefix(name, "cpu-thermal") {
-			cpuTemp, err := parseTemperatureFile(filepath.Join(file, "temp"))
+			cpuTemp, err := parseTemperatureFile(ctx, filepath.Join(file, "temp"))
 			if err != nil {
 				continue
 			}
@@ -208,11 +208,11 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 }
 
 // parseTemperatureFile reads a temperature file and returns the temperature in degrees Celsius
-func parseTemperatureFile(file string) (float64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), utils.KernelVirtualFSReadTimeout)
+func parseTemperatureFile(ctx context.Context, file string) (float64, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
 	defer cancel()
 
-	raw, err := utils.ReadFileContext(ctx, file)
+	raw, err := utils.ReadFileWithContext(ctxWithTimeout, file)
 	if err != nil {
 		return 0, err
 	}
@@ -226,9 +226,13 @@ func parseTemperatureFile(file string) (float64, error) {
 }
 
 // getThermalZoneFiles returns a list of temperature files in /sys/class/thermal/thermal_zone*/temp
-func getThermalZoneFiles() ([]string, error) {
+func getThermalZoneFiles(ctx context.Context) ([]string, error) {
 	globPath := filepath.Join(linux.SysFS, "class", "thermal", "thermal_zone*")
-	files, err := filepath.Glob(globPath)
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	files, err := utils.GlobWithContext(ctxWithTimeout, globPath)
 	if err != nil {
 		return nil, err
 	}
@@ -237,9 +241,13 @@ func getThermalZoneFiles() ([]string, error) {
 }
 
 // getHwMonFiles returns a list of temperature files in /sys/class/hwmon/hwmon*/temp*_input
-func getHwMonFiles() ([]string, error) {
+func getHwMonFiles(ctx context.Context) ([]string, error) {
 	globPath := filepath.Join(linux.SysFS, "class", "hwmon", "hwmon*", "temp*_input")
-	files, err := filepath.Glob(globPath)
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+	defer cancel()
+
+	files, err := utils.GlobWithContext(ctxWithTimeout, globPath)
 	if err != nil {
 		return nil, err
 	}
@@ -247,8 +255,12 @@ func getHwMonFiles() ([]string, error) {
 	if len(files) == 0 {
 		// CentOS has an intermediate /device directory:
 		// https://github.com/giampaolo/psutil/issues/971
+
+		ctxWithTimeoutInner, cancelInner := context.WithTimeout(ctx, utils.KernelVirtualFSReadTimeout)
+		defer cancelInner()
+
 		globPath = filepath.Join(linux.SysFS, "class", "hwmon", "hwmon*", "device", "temp*_input")
-		if files, err = filepath.Glob(globPath); err != nil {
+		if files, err = utils.GlobWithContext(ctxWithTimeoutInner, globPath); err != nil {
 			return nil, err
 		}
 	}

--- a/app/metrics/temperature_test.go
+++ b/app/metrics/temperature_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestCollectTemperature(t *testing.T) {
 
-	metrics, _ := CollectTemperature()
+	metrics, _ := CollectTemperature(t.Context())
 
 	if len(metrics) == 0 {
 		t.Skip("no temperature metrics available")

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -2,11 +2,11 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -54,7 +54,9 @@ func SetGoroutineCountForTesting(count int64) {
 	atomic.StoreInt64(&goroutineCount, count)
 }
 
-// reserveGoroutineSlot attempts to reserve a slot for a new goroutine. It returns true if successful, false if the maximum number of goroutines has been reached.
+// reserveGoroutineSlot attempts to reserve a slot for a new goroutine. It returns true if successful, false if the
+// maximum number of goroutines has been reached. This method is safe for Time-of-Check to Time-of-Use (TOCTOU) race
+// conditions. For loop ensures retries until the slot is successfully reserved or the maximum number of goroutines is reached.
 func reserveGoroutineSlot() bool {
 	for {
 		current := atomic.LoadInt64(&goroutineCount)
@@ -68,6 +70,19 @@ func reserveGoroutineSlot() bool {
 	}
 }
 
+// releaseGoroutineSlot releases a previously reserved goroutine slot. It decrements the goroutine count if the error is nil
+// or not a context deadline exceeded error (context.DeadlineExceeded).
+func releaseGoroutineSlot(err error) {
+	if err == nil {
+		atomic.AddInt64(&goroutineCount, -1)
+		return
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		atomic.AddInt64(&goroutineCount, -1)
+		return
+	}
+}
+
 // KernelVirtualFSReadTimeout limits reads/opens on virtual kernel filesystems.
 const KernelVirtualFSReadTimeout = 2 * time.Second
 
@@ -78,39 +93,18 @@ func ReadFileWithContext(ctx context.Context, filePath string) ([]byte, error) {
 		return nil, err
 	}
 
-	closer, hasCloser := reader.(io.Closer)
-
-	type result struct {
-		data []byte
-		err  error
-	}
-
-	ch := make(chan result, 1)
-
-	go func() {
-		data, err := io.ReadAll(reader)
-		ch <- result{data, err}
-	}()
-
-	select {
-	case <-ctx.Done():
-		if hasCloser {
-			_ = closer.Close()
-		}
-		return nil, ctx.Err()
-	case res := <-ch:
-		if hasCloser {
-			_ = closer.Close()
-		}
-		return res.data, res.err
-	}
+	return reader.(*contextReader).ReadAll()
 }
 
 // OpenFileWithContext opens a file with context cancellation support.
-func OpenFileWithContext(ctx context.Context, filePath string) (io.Reader, error) {
+func OpenFileWithContext(ctx context.Context, filePath string) (openedFile io.Reader, openErr error) {
 	if !reserveGoroutineSlot() {
 		return nil, fmt.Errorf("goroutine budget exhausted")
 	}
+
+	defer func() {
+		releaseGoroutineSlot(openErr)
+	}()
 
 	ch := make(chan *os.File)
 	errCh := make(chan error, 1)
@@ -118,94 +112,118 @@ func OpenFileWithContext(ctx context.Context, filePath string) (io.Reader, error
 	go func() {
 		f, err := os.Open(filePath)
 		if err != nil {
-			atomic.AddInt64(&goroutineCount, -1)
 			errCh <- err
 			return
 		}
-
-		select {
-		case <-ctx.Done():
-			_ = f.Close()
-			atomic.AddInt64(&goroutineCount, -1)
-		case ch <- f:
-		}
+		ch <- f
 	}()
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
-	case err := <-errCh:
-		return nil, err
+		openErr = ctx.Err()
+		return nil, openErr
+	case openErr = <-errCh:
+		return nil, openErr
 	case f := <-ch:
-		return &contextReader{
-			ctx:  ctx,
-			f:    f,
-			done: func() { atomic.AddInt64(&goroutineCount, -1) },
-		}, nil
+		openedFile = &contextReader{
+			ctx: ctx,
+			f:   f,
+		}
+		return openedFile, nil
 	}
 }
 
 type contextReader struct {
-	ctx  context.Context
-	f    *os.File
-	done func()
-	once sync.Once
+	ctx context.Context
+	f   *os.File
 }
 
-func (cr *contextReader) markDone() {
-	cr.once.Do(cr.done)
-}
+// Read reads from the contextReader, respecting context cancellation. If the context is done, it closes the underlying file and returns an error.
+func (cr *contextReader) Read(p []byte) (readBytes int, readErr error) {
+	if !reserveGoroutineSlot() {
+		return 0, fmt.Errorf("goroutine budget exhausted")
+	}
 
-func (cr *contextReader) Read(p []byte) (n int, err error) {
+	defer func() {
+		releaseGoroutineSlot(readErr)
+	}()
+
+	errChan := make(chan error, 1)
+	ch := make(chan int, 1)
+	go func() {
+		n, err := cr.f.Read(p)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		ch <- n
+	}()
+
 	select {
 	case <-cr.ctx.Done():
-		_ = cr.f.Close()
-		cr.markDone()
-		return 0, cr.ctx.Err()
-	default:
+		_ = cr.Close()
+		readErr = cr.ctx.Err()
+		return 0, readErr
+	case readErr = <-errChan:
+		return 0, readErr
+	case readBytes = <-ch:
+		return readBytes, nil
 	}
-
-	n, err = cr.f.Read(p)
-	if err != nil {
-		cr.markDone()
-	}
-
-	return n, err
 }
 
+// ReadAll reads all data from the contextReader, respecting context cancellation. If the context is done, it closes the underlying file and returns an error.
+func (cr *contextReader) ReadAll() ([]byte, error) {
+	var result []byte
+	buf := make([]byte, 4096)
+	for {
+		n, err := cr.Read(buf)
+		if n > 0 {
+			result = append(result, buf[:n]...)
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return result, nil
+			}
+			return result, err
+		}
+	}
+}
+
+// Close closes the contextReader, releasing the underlying file and goroutine slot.
 func (cr *contextReader) Close() error {
-	err := cr.f.Close()
-	cr.markDone()
-	return err
+	return cr.f.Close()
 }
 
-func GlobWithContext(ctx context.Context, pattern string) ([]string, error) {
+// GlobWithContext performs a filepath.Glob operation with context cancellation support.
+// This function performs a filepath.Glob operation while respecting context cancellation
+// which prevents blocking on slow or unresponsive filesystems.
+func GlobWithContext(ctx context.Context, pattern string) (matches []string, err error) {
 	if !reserveGoroutineSlot() {
 		return nil, fmt.Errorf("goroutine budget exhausted")
 	}
+
+	defer func() {
+		releaseGoroutineSlot(err)
+	}()
 
 	ch := make(chan []string, 1)
 	errCh := make(chan error, 1)
 
 	go func() {
-		defer atomic.AddInt64(&goroutineCount, -1)
-
 		matches, err := filepath.Glob(pattern)
 		if err != nil {
 			errCh <- err
 			return
 		}
 
-		select {
-		case <-ctx.Done():
-		case ch <- matches:
-		}
+		ch <- matches
 	}()
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
-	case err := <-errCh:
+		err = ctx.Err()
+		return nil, err
+	case err = <-errCh:
 		return nil, err
 	case matches := <-ch:
 		return matches, nil
@@ -213,11 +231,16 @@ func GlobWithContext(ctx context.Context, pattern string) ([]string, error) {
 }
 
 // ListDirectoryWithContext lists files and directories in a directory with context cancellation support.
-// This prevents blocking reads on virtual filesystems like procfs.
-func ListDirectoryWithContext(ctx context.Context, dirPath string) ([]string, error) {
+// This function lists the contents of a directory while respecting context cancellation, preventing
+// blocking on slow or unresponsive filesystems.
+func ListDirectoryWithContext(ctx context.Context, dirPath string) (names []string, listErr error) {
 	if !reserveGoroutineSlot() {
 		return nil, fmt.Errorf("goroutine budget exhausted")
 	}
+
+	defer func() {
+		releaseGoroutineSlot(listErr)
+	}()
 
 	ch := make(chan []string, 1)
 	errCh := make(chan error, 1)
@@ -225,7 +248,6 @@ func ListDirectoryWithContext(ctx context.Context, dirPath string) ([]string, er
 	go func() {
 		dir, err := os.Open(dirPath)
 		if err != nil {
-			atomic.AddInt64(&goroutineCount, -1)
 			errCh <- fmt.Errorf("error opening %s: %w", dirPath, err)
 			return
 		}
@@ -234,25 +256,19 @@ func ListDirectoryWithContext(ctx context.Context, dirPath string) ([]string, er
 
 		dirNames, err := dir.Readdirnames(-1)
 		if err != nil {
-			atomic.AddInt64(&goroutineCount, -1)
 			errCh <- fmt.Errorf("error listing contents of %s: %w", dirPath, err)
 			return
 		}
-
-		select {
-		case <-ctx.Done():
-			atomic.AddInt64(&goroutineCount, -1)
-		case ch <- dirNames:
-		}
+		ch <- dirNames
 	}()
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
-	case err := <-errCh:
-		return nil, err
+		listErr = ctx.Err()
+		return nil, listErr
+	case listErr = <-errCh:
+		return nil, listErr
 	case names := <-ch:
-		atomic.AddInt64(&goroutineCount, -1)
 		return names, nil
 	}
 }

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -41,6 +41,7 @@ func WriteFileSync(name string, data []byte, perm os.FileMode) error {
 // goroutineCount tracks the number of active goroutines
 var goroutineCount int64
 
+// maxGoroutines defines the maximum number of concurrent goroutines allowed for file IO operations.
 const maxGoroutines = 500
 
 // GoroutinesExhausted reports whether the context file IO goroutine budget is exhausted.
@@ -72,15 +73,8 @@ func reserveGoroutineSlot() bool {
 
 // releaseGoroutineSlot releases a previously reserved goroutine slot. It decrements the goroutine count if the error is nil
 // or not a context deadline exceeded error (context.DeadlineExceeded).
-func releaseGoroutineSlot(err error) {
-	if err == nil {
-		atomic.AddInt64(&goroutineCount, -1)
-		return
-	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		atomic.AddInt64(&goroutineCount, -1)
-		return
-	}
+func releaseGoroutineSlot() {
+	atomic.AddInt64(&goroutineCount, -1)
 }
 
 // KernelVirtualFSReadTimeout limits reads/opens on virtual kernel filesystems.
@@ -93,23 +87,27 @@ func ReadFileWithContext(ctx context.Context, filePath string) ([]byte, error) {
 		return nil, err
 	}
 
+	defer func() {
+		_ = reader.(*contextReader).Close()
+	}()
+
 	return reader.(*contextReader).ReadAll()
 }
 
 // OpenFileWithContext opens a file with context cancellation support.
-func OpenFileWithContext(ctx context.Context, filePath string) (openedFile io.Reader, openErr error) {
+func OpenFileWithContext(ctx context.Context, filePath string) (io.Reader, error) {
 	if !reserveGoroutineSlot() {
 		return nil, fmt.Errorf("goroutine budget exhausted")
 	}
-
-	defer func() {
-		releaseGoroutineSlot(openErr)
-	}()
 
 	ch := make(chan *os.File)
 	errCh := make(chan error, 1)
 
 	go func() {
+		defer func() {
+			releaseGoroutineSlot()
+		}()
+
 		f, err := os.Open(filePath)
 		if err != nil {
 			errCh <- err
@@ -120,16 +118,14 @@ func OpenFileWithContext(ctx context.Context, filePath string) (openedFile io.Re
 
 	select {
 	case <-ctx.Done():
-		openErr = ctx.Err()
-		return nil, openErr
-	case openErr = <-errCh:
-		return nil, openErr
+		return nil, ctx.Err()
+	case err := <-errCh:
+		return nil, err
 	case f := <-ch:
-		openedFile = &contextReader{
+		return &contextReader{
 			ctx: ctx,
 			f:   f,
-		}
-		return openedFile, nil
+		}, nil
 	}
 }
 
@@ -139,18 +135,18 @@ type contextReader struct {
 }
 
 // Read reads from the contextReader, respecting context cancellation. If the context is done, it closes the underlying file and returns an error.
-func (cr *contextReader) Read(p []byte) (readBytes int, readErr error) {
+func (cr *contextReader) Read(p []byte) (int, error) {
 	if !reserveGoroutineSlot() {
 		return 0, fmt.Errorf("goroutine budget exhausted")
 	}
 
-	defer func() {
-		releaseGoroutineSlot(readErr)
-	}()
-
 	errChan := make(chan error, 1)
 	ch := make(chan int, 1)
 	go func() {
+		defer func() {
+			releaseGoroutineSlot()
+		}()
+
 		n, err := cr.f.Read(p)
 		if err != nil {
 			errChan <- err
@@ -161,13 +157,11 @@ func (cr *contextReader) Read(p []byte) (readBytes int, readErr error) {
 
 	select {
 	case <-cr.ctx.Done():
-		_ = cr.Close()
-		readErr = cr.ctx.Err()
-		return 0, readErr
-	case readErr = <-errChan:
-		return 0, readErr
-	case readBytes = <-ch:
-		return readBytes, nil
+		return 0, cr.ctx.Err()
+	case err := <-errChan:
+		return 0, err
+	case n := <-ch:
+		return n, nil
 	}
 }
 
@@ -197,19 +191,19 @@ func (cr *contextReader) Close() error {
 // GlobWithContext performs a filepath.Glob operation with context cancellation support.
 // This function performs a filepath.Glob operation while respecting context cancellation
 // which prevents blocking on slow or unresponsive filesystems.
-func GlobWithContext(ctx context.Context, pattern string) (matches []string, err error) {
+func GlobWithContext(ctx context.Context, pattern string) ([]string, error) {
 	if !reserveGoroutineSlot() {
 		return nil, fmt.Errorf("goroutine budget exhausted")
 	}
-
-	defer func() {
-		releaseGoroutineSlot(err)
-	}()
 
 	ch := make(chan []string, 1)
 	errCh := make(chan error, 1)
 
 	go func() {
+		defer func() {
+			releaseGoroutineSlot()
+		}()
+
 		matches, err := filepath.Glob(pattern)
 		if err != nil {
 			errCh <- err
@@ -221,9 +215,8 @@ func GlobWithContext(ctx context.Context, pattern string) (matches []string, err
 
 	select {
 	case <-ctx.Done():
-		err = ctx.Err()
-		return nil, err
-	case err = <-errCh:
+		return nil, ctx.Err()
+	case err := <-errCh:
 		return nil, err
 	case matches := <-ch:
 		return matches, nil
@@ -233,22 +226,22 @@ func GlobWithContext(ctx context.Context, pattern string) (matches []string, err
 // ListDirectoryWithContext lists files and directories in a directory with context cancellation support.
 // This function lists the contents of a directory while respecting context cancellation, preventing
 // blocking on slow or unresponsive filesystems.
-func ListDirectoryWithContext(ctx context.Context, dirPath string) (names []string, listErr error) {
+func ListDirectoryWithContext(ctx context.Context, dirPath string) ([]string, error) {
 	if !reserveGoroutineSlot() {
 		return nil, fmt.Errorf("goroutine budget exhausted")
 	}
-
-	defer func() {
-		releaseGoroutineSlot(listErr)
-	}()
 
 	ch := make(chan []string, 1)
 	errCh := make(chan error, 1)
 
 	go func() {
+		defer func() {
+			releaseGoroutineSlot()
+		}()
+
 		dir, err := os.Open(dirPath)
 		if err != nil {
-			errCh <- fmt.Errorf("error opening %s: %w", dirPath, err)
+			errCh <- err
 			return
 		}
 
@@ -256,7 +249,7 @@ func ListDirectoryWithContext(ctx context.Context, dirPath string) (names []stri
 
 		dirNames, err := dir.Readdirnames(-1)
 		if err != nil {
-			errCh <- fmt.Errorf("error listing contents of %s: %w", dirPath, err)
+			errCh <- err
 			return
 		}
 		ch <- dirNames
@@ -264,10 +257,9 @@ func ListDirectoryWithContext(ctx context.Context, dirPath string) (names []stri
 
 	select {
 	case <-ctx.Done():
-		listErr = ctx.Err()
-		return nil, listErr
-	case listErr = <-errCh:
-		return nil, listErr
+		return nil, ctx.Err()
+	case err := <-errCh:
+		return nil, err
 	case names := <-ch:
 		return names, nil
 	}

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -113,7 +113,12 @@ func OpenFileWithContext(ctx context.Context, filePath string) (io.Reader, error
 			errCh <- err
 			return
 		}
-		ch <- f
+
+		select {
+		case ch <- f:
+		case <-ctx.Done():
+			_ = f.Close()
+		}
 	}()
 
 	select {

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -48,6 +48,12 @@ func GoroutinesExhausted() bool {
 	return atomic.LoadInt64(&goroutineCount) >= maxGoroutines
 }
 
+// SetGoroutineCountForTesting sets the goroutine count for testing purposes.
+// This is only intended for use in tests.
+func SetGoroutineCountForTesting(count int64) {
+	atomic.StoreInt64(&goroutineCount, count)
+}
+
 // reserveGoroutineSlot attempts to reserve a slot for a new goroutine. It returns true if successful, false if the maximum number of goroutines has been reached.
 func reserveGoroutineSlot() bool {
 	for {

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -88,50 +87,40 @@ func ReadFileWithContext(ctx context.Context, filePath string) ([]byte, error) {
 	}
 
 	defer func() {
-		_ = reader.(*contextReader).Close()
+		_ = reader.Close()
 	}()
 
-	return reader.(*contextReader).ReadAll()
+	// ReadAll calls reader.Read which will respect the context cancellation due to the contextReader implementation.
+	return io.ReadAll(reader)
 }
 
 // OpenFileWithContext opens a file with context cancellation support.
-func OpenFileWithContext(ctx context.Context, filePath string) (io.Reader, error) {
-	if !reserveGoroutineSlot() {
-		return nil, fmt.Errorf("goroutine budget exhausted")
-	}
+func OpenFileWithContext(ctx context.Context, filePath string) (io.ReadCloser, error) {
+	var f *os.File
 
-	ch := make(chan *os.File)
-	errCh := make(chan error, 1)
-
-	go func() {
-		defer func() {
-			releaseGoroutineSlot()
-		}()
-
-		f, err := os.Open(filePath)
+	outerErr := fileOperationWithContext(ctx, func() error {
+		var err error
+		f, err = os.Open(filePath)
 		if err != nil {
-			errCh <- err
-			return
+			return err
 		}
 
 		select {
-		case ch <- f:
 		case <-ctx.Done():
 			_ = f.Close()
+			return ctx.Err()
+		default:
 		}
-	}()
+		return nil
+	})
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case err := <-errCh:
-		return nil, err
-	case f := <-ch:
-		return &contextReader{
-			ctx: ctx,
-			f:   f,
-		}, nil
+	if outerErr != nil {
+		return nil, outerErr
 	}
+	return &contextReader{
+		ctx: ctx,
+		f:   f,
+	}, nil
 }
 
 type contextReader struct {
@@ -170,24 +159,6 @@ func (cr *contextReader) Read(p []byte) (int, error) {
 	}
 }
 
-// ReadAll reads all data from the contextReader, respecting context cancellation. If the context is done, it closes the underlying file and returns an error.
-func (cr *contextReader) ReadAll() ([]byte, error) {
-	var result []byte
-	buf := make([]byte, 4096)
-	for {
-		n, err := cr.Read(buf)
-		if n > 0 {
-			result = append(result, buf[:n]...)
-		}
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return result, nil
-			}
-			return result, err
-		}
-	}
-}
-
 // Close closes the contextReader, releasing the underlying file and goroutine slot.
 func (cr *contextReader) Close() error {
 	return cr.f.Close()
@@ -197,46 +168,78 @@ func (cr *contextReader) Close() error {
 // This function performs a filepath.Glob operation while respecting context cancellation
 // which prevents blocking on slow or unresponsive filesystems.
 func GlobWithContext(ctx context.Context, pattern string) ([]string, error) {
-	if !reserveGoroutineSlot() {
-		return nil, fmt.Errorf("goroutine budget exhausted")
-	}
+	var result []string
 
-	ch := make(chan []string, 1)
-	errCh := make(chan error, 1)
-
-	go func() {
-		defer func() {
-			releaseGoroutineSlot()
-		}()
-
-		matches, err := filepath.Glob(pattern)
+	outerErr := fileOperationWithContext(ctx, func() error {
+		var err error
+		result, err = filepath.Glob(pattern)
 		if err != nil {
-			errCh <- err
-			return
+			return err
 		}
+		return nil
+	})
 
-		ch <- matches
-	}()
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case err := <-errCh:
-		return nil, err
-	case matches := <-ch:
-		return matches, nil
+	if outerErr != nil {
+		return nil, outerErr
 	}
+	return result, nil
 }
 
 // ListDirectoryWithContext lists files and directories in a directory with context cancellation support.
 // This function lists the contents of a directory while respecting context cancellation, preventing
 // blocking on slow or unresponsive filesystems.
 func ListDirectoryWithContext(ctx context.Context, dirPath string) ([]string, error) {
+	var result []string
+
+	outerErr := fileOperationWithContext(ctx, func() error {
+		dir, err := os.Open(dirPath)
+		if err != nil {
+			return err
+		}
+
+		defer func() { _ = dir.Close() }()
+
+		result, err = dir.Readdirnames(-1)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if outerErr != nil {
+		return nil, outerErr
+	}
+	return result, nil
+}
+
+// StatWithContext performs an os.Stat operation with context cancellation support.
+// This function retrieves the FileInfo of a file or directory while respecting context cancellation,
+// preventing blocking on slow or unresponsive filesystems.
+func StatWithContext(ctx context.Context, path string) (os.FileInfo, error) {
+	var result os.FileInfo
+
+	outerErr := fileOperationWithContext(ctx, func() error {
+		var err error
+		result, err = os.Stat(path)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if outerErr != nil {
+		return nil, outerErr
+	}
+	return result, nil
+}
+
+// fileOperationWithContext executes a file operation in a separate goroutine while respecting context cancellation.
+// It ensures that the operation does not block the main goroutine and releases the goroutine slot after completion.
+func fileOperationWithContext(ctx context.Context, operation func() error) error {
 	if !reserveGoroutineSlot() {
-		return nil, fmt.Errorf("goroutine budget exhausted")
+		return fmt.Errorf("goroutine budget exhausted")
 	}
 
-	ch := make(chan []string, 1)
 	errCh := make(chan error, 1)
 
 	go func() {
@@ -244,28 +247,13 @@ func ListDirectoryWithContext(ctx context.Context, dirPath string) ([]string, er
 			releaseGoroutineSlot()
 		}()
 
-		dir, err := os.Open(dirPath)
-		if err != nil {
-			errCh <- err
-			return
-		}
-
-		defer func() { _ = dir.Close() }()
-
-		dirNames, err := dir.Readdirnames(-1)
-		if err != nil {
-			errCh <- err
-			return
-		}
-		ch <- dirNames
+		errCh <- operation()
 	}()
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return ctx.Err()
 	case err := <-errCh:
-		return nil, err
-	case names := <-ch:
-		return names, nil
+		return err
 	}
 }

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -112,7 +112,7 @@ func OpenFileWithContext(ctx context.Context, filePath string) (io.Reader, error
 		return nil, fmt.Errorf("goroutine budget exhausted")
 	}
 
-ch := make(chan *os.File)
+	ch := make(chan *os.File)
 	errCh := make(chan error, 1)
 
 	go func() {
@@ -187,7 +187,7 @@ func GlobWithContext(ctx context.Context, pattern string) ([]string, error) {
 	ch := make(chan []string, 1)
 	errCh := make(chan error, 1)
 
-go func() {
+	go func() {
 		defer atomic.AddInt64(&goroutineCount, -1)
 
 		matches, err := filepath.Glob(pattern)

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -78,11 +78,32 @@ func ReadFileWithContext(ctx context.Context, filePath string) ([]byte, error) {
 		return nil, err
 	}
 
-	if closer, ok := reader.(io.Closer); ok {
-		defer func() { _ = closer.Close() }()
+	closer, hasCloser := reader.(io.Closer)
+
+	type result struct {
+		data []byte
+		err  error
 	}
 
-	return io.ReadAll(reader)
+	ch := make(chan result, 1)
+
+	go func() {
+		data, err := io.ReadAll(reader)
+		ch <- result{data, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		if hasCloser {
+			_ = closer.Close()
+		}
+		return nil, ctx.Err()
+	case res := <-ch:
+		if hasCloser {
+			_ = closer.Close()
+		}
+		return res.data, res.err
+	}
 }
 
 // OpenFileWithContext opens a file with context cancellation support.

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -166,17 +166,17 @@ func GlobWithContext(ctx context.Context, pattern string) ([]string, error) {
 	ch := make(chan []string, 1)
 	errCh := make(chan error, 1)
 
-	go func() {
+go func() {
+		defer atomic.AddInt64(&goroutineCount, -1)
+
 		matches, err := filepath.Glob(pattern)
 		if err != nil {
-			atomic.AddInt64(&goroutineCount, -1)
 			errCh <- err
 			return
 		}
 
 		select {
 		case <-ctx.Done():
-			atomic.AddInt64(&goroutineCount, -1)
 		case ch <- matches:
 		}
 	}()

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -54,6 +54,12 @@ func SetGoroutineCountForTesting(count int64) {
 	atomic.StoreInt64(&goroutineCount, count)
 }
 
+// GetGoroutineCount returns the current goroutine count for testing purposes.
+// This is only intended for use in tests.
+func GetGoroutineCount() int64 {
+	return atomic.LoadInt64(&goroutineCount)
+}
+
 // reserveGoroutineSlot attempts to reserve a slot for a new goroutine. It returns true if successful, false if the
 // maximum number of goroutines has been reached. This method is safe for Time-of-Check to Time-of-Use (TOCTOU) race
 // conditions. For loop ensures retries until the slot is successfully reserved or the maximum number of goroutines is reached.

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -2,9 +2,12 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // WriteFileSync writes data to a file named by filename and syncs to disk.
@@ -39,47 +42,64 @@ var goroutineCount int64
 
 const maxGoroutines = 500
 
-func ReadFileContext(ctx context.Context, filePath string) ([]byte, error) {
-	atomic.AddInt64(&goroutineCount, 1)
-	defer atomic.AddInt64(&goroutineCount, -1)
+// GoroutinesExhausted reports whether the context file IO goroutine budget is exhausted.
+func GoroutinesExhausted() bool {
+	return atomic.LoadInt64(&goroutineCount) >= maxGoroutines
+}
 
-	ch := make(chan []byte, 1)
-	errCh := make(chan error, 1)
-
-	go func() {
-		data, err := os.ReadFile(filePath)
-		if err != nil {
-			errCh <- err
-			return
+// reserveGoroutineSlot attempts to reserve a slot for a new goroutine. It returns true if successful, false if the maximum number of goroutines has been reached.
+func reserveGoroutineSlot() bool {
+	for {
+		current := atomic.LoadInt64(&goroutineCount)
+		if current >= maxGoroutines {
+			return false
 		}
-		ch <- data
-	}()
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case err := <-errCh:
-		return nil, err
-	case data := <-ch:
-		return data, nil
+		if atomic.CompareAndSwapInt64(&goroutineCount, current, current+1) {
+			return true
+		}
 	}
+}
+
+// KernelVirtualFSReadTimeout limits reads/opens on virtual kernel filesystems.
+const KernelVirtualFSReadTimeout = 2 * time.Second
+
+func ReadFileContext(ctx context.Context, filePath string) ([]byte, error) {
+	reader, err := OpenFileContext(ctx, filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if closer, ok := reader.(io.Closer); ok {
+		defer func() { _ = closer.Close() }()
+	}
+
+	return io.ReadAll(reader)
 }
 
 // OpenFileContext opens a file with context cancellation support.
 func OpenFileContext(ctx context.Context, filePath string) (io.Reader, error) {
-	atomic.AddInt64(&goroutineCount, 1)
+	if !reserveGoroutineSlot() {
+		return nil, fmt.Errorf("goroutine budget exhausted")
+	}
 
 	ch := make(chan *os.File, 1)
 	errCh := make(chan error, 1)
 
 	go func() {
-		defer atomic.AddInt64(&goroutineCount, -1)
 		f, err := os.Open(filePath)
 		if err != nil {
+			atomic.AddInt64(&goroutineCount, -1)
 			errCh <- err
 			return
 		}
-		ch <- f
+
+		select {
+		case <-ctx.Done():
+			_ = f.Close()
+			atomic.AddInt64(&goroutineCount, -1)
+		case ch <- f:
+		}
 	}()
 
 	select {
@@ -89,23 +109,43 @@ func OpenFileContext(ctx context.Context, filePath string) (io.Reader, error) {
 		return nil, err
 	case f := <-ch:
 		return &contextReader{
-			ctx: ctx,
-			f:   f,
+			ctx:  ctx,
+			f:    f,
+			done: func() { atomic.AddInt64(&goroutineCount, -1) },
 		}, nil
 	}
 }
 
 type contextReader struct {
-	ctx context.Context
-	f   *os.File
+	ctx  context.Context
+	f    *os.File
+	done func()
+	once sync.Once
+}
+
+func (cr *contextReader) markDone() {
+	cr.once.Do(cr.done)
 }
 
 func (cr *contextReader) Read(p []byte) (n int, err error) {
 	select {
 	case <-cr.ctx.Done():
-		cr.f.Close()
+		_ = cr.f.Close()
+		cr.markDone()
 		return 0, cr.ctx.Err()
 	default:
 	}
-	return cr.f.Read(p)
+
+	n, err = cr.f.Read(p)
+	if err != nil {
+		cr.markDone()
+	}
+
+	return n, err
+}
+
+func (cr *contextReader) Close() error {
+	err := cr.f.Close()
+	cr.markDone()
+	return err
 }

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -91,7 +91,7 @@ func OpenFileWithContext(ctx context.Context, filePath string) (io.Reader, error
 		return nil, fmt.Errorf("goroutine budget exhausted")
 	}
 
-	ch := make(chan *os.File, 1)
+ch := make(chan *os.File)
 	errCh := make(chan error, 1)
 
 	go func() {

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -184,3 +184,48 @@ func GlobWithContext(ctx context.Context, pattern string) ([]string, error) {
 		return matches, nil
 	}
 }
+
+// ListDirectoryWithContext lists files and directories in a directory with context cancellation support.
+// This prevents blocking reads on virtual filesystems like procfs.
+func ListDirectoryWithContext(ctx context.Context, dirPath string) ([]string, error) {
+	if !reserveGoroutineSlot() {
+		return nil, fmt.Errorf("goroutine budget exhausted")
+	}
+
+	ch := make(chan []string, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		dir, err := os.Open(dirPath)
+		if err != nil {
+			atomic.AddInt64(&goroutineCount, -1)
+			errCh <- fmt.Errorf("error opening %s: %w", dirPath, err)
+			return
+		}
+
+		defer func() { _ = dir.Close() }()
+
+		dirNames, err := dir.Readdirnames(-1)
+		if err != nil {
+			atomic.AddInt64(&goroutineCount, -1)
+			errCh <- fmt.Errorf("error listing contents of %s: %w", dirPath, err)
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			atomic.AddInt64(&goroutineCount, -1)
+		case ch <- dirNames:
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-errCh:
+		return nil, err
+	case names := <-ch:
+		atomic.AddInt64(&goroutineCount, -1)
+		return names, nil
+	}
+}

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -64,8 +65,9 @@ func reserveGoroutineSlot() bool {
 // KernelVirtualFSReadTimeout limits reads/opens on virtual kernel filesystems.
 const KernelVirtualFSReadTimeout = 2 * time.Second
 
-func ReadFileContext(ctx context.Context, filePath string) ([]byte, error) {
-	reader, err := OpenFileContext(ctx, filePath)
+// ReadFileWithContext reads the contents of a file with context cancellation support.
+func ReadFileWithContext(ctx context.Context, filePath string) ([]byte, error) {
+	reader, err := OpenFileWithContext(ctx, filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -77,8 +79,8 @@ func ReadFileContext(ctx context.Context, filePath string) ([]byte, error) {
 	return io.ReadAll(reader)
 }
 
-// OpenFileContext opens a file with context cancellation support.
-func OpenFileContext(ctx context.Context, filePath string) (io.Reader, error) {
+// OpenFileWithContext opens a file with context cancellation support.
+func OpenFileWithContext(ctx context.Context, filePath string) (io.Reader, error) {
 	if !reserveGoroutineSlot() {
 		return nil, fmt.Errorf("goroutine budget exhausted")
 	}
@@ -148,4 +150,37 @@ func (cr *contextReader) Close() error {
 	err := cr.f.Close()
 	cr.markDone()
 	return err
+}
+
+func GlobWithContext(ctx context.Context, pattern string) ([]string, error) {
+	if !reserveGoroutineSlot() {
+		return nil, fmt.Errorf("goroutine budget exhausted")
+	}
+
+	ch := make(chan []string, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			atomic.AddInt64(&goroutineCount, -1)
+			errCh <- err
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			atomic.AddInt64(&goroutineCount, -1)
+		case ch <- matches:
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-errCh:
+		return nil, err
+	case matches := <-ch:
+		return matches, nil
+	}
 }

--- a/app/utils/files.go
+++ b/app/utils/files.go
@@ -1,6 +1,11 @@
 package utils
 
-import "os"
+import (
+	"context"
+	"io"
+	"os"
+	"sync/atomic"
+)
 
 // WriteFileSync writes data to a file named by filename and syncs to disk.
 func WriteFileSync(name string, data []byte, perm os.FileMode) error {
@@ -27,4 +32,80 @@ func WriteFileSync(name string, data []byte, perm os.FileMode) error {
 	}
 
 	return err
+}
+
+// goroutineCount tracks the number of active goroutines
+var goroutineCount int64
+
+const maxGoroutines = 500
+
+func ReadFileContext(ctx context.Context, filePath string) ([]byte, error) {
+	atomic.AddInt64(&goroutineCount, 1)
+	defer atomic.AddInt64(&goroutineCount, -1)
+
+	ch := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		ch <- data
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-errCh:
+		return nil, err
+	case data := <-ch:
+		return data, nil
+	}
+}
+
+// OpenFileContext opens a file with context cancellation support.
+func OpenFileContext(ctx context.Context, filePath string) (io.Reader, error) {
+	atomic.AddInt64(&goroutineCount, 1)
+
+	ch := make(chan *os.File, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer atomic.AddInt64(&goroutineCount, -1)
+		f, err := os.Open(filePath)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		ch <- f
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-errCh:
+		return nil, err
+	case f := <-ch:
+		return &contextReader{
+			ctx: ctx,
+			f:   f,
+		}, nil
+	}
+}
+
+type contextReader struct {
+	ctx context.Context
+	f   *os.File
+}
+
+func (cr *contextReader) Read(p []byte) (n int, err error) {
+	select {
+	case <-cr.ctx.Done():
+		cr.f.Close()
+		return 0, cr.ctx.Err()
+	default:
+	}
+	return cr.f.Read(p)
 }

--- a/app/utils/files_test.go
+++ b/app/utils/files_test.go
@@ -2,12 +2,13 @@ package utils
 
 import (
 	"context"
-	"os"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
+
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func TestExhaustGoRoutines(t *testing.T) {
@@ -21,69 +22,41 @@ func TestExhaustGoRoutines(t *testing.T) {
 		}
 	}
 
-	// Now, the goroutine count should be at maxGoroutines
-	if !GoroutinesExhausted() {
-		t.Fatalf("Expected GoroutinesExhausted to return true, but got false")
-	}
+	// Check that GoroutinesExhausted returns true when all slots are reserved
+	assert.True(t, GoroutinesExhausted())
 
 	// Try to reserve one more slot, which should fail
-	if reserveGoroutineSlot() {
-		t.Fatalf("Expected reserveGoroutineSlot to return false when max goroutines reached, but got true")
-	}
+	assert.False(t, reserveGoroutineSlot())
 }
 
 func TestExhaustGoRoutinesPipeReads(t *testing.T) {
 
 	fifoPath := t.TempDir() + "/test_fifo"
-	err := exhaustGoRoutines(t.Context(), fifoPath)
-	if err != nil {
-		t.Fatalf("Failed to exhaust goroutines: %v", err)
-	}
 
-	if got := atomic.LoadInt64(&goroutineCount); got != int64(maxGoroutines) {
-		t.Fatalf("Expected goroutine count to stay at maxGoroutines (%d), got %d", maxGoroutines, got)
-	}
-
-	// try to read once more, which should fail to reserve a slot
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-	_, err = ReadFileWithContext(ctx, fifoPath)
-
-	if err == nil {
-		t.Fatalf("Expected ReadFileContext to fail due to exhausted goroutines, but it succeeded")
-	}
-
-	if got := atomic.LoadInt64(&goroutineCount); got != int64(maxGoroutines) {
-		t.Fatalf("Expected goroutine count to stay at maxGoroutines (%d) after additional read, got %d", maxGoroutines, got)
-	}
-}
-
-// ExhaustGoRoutines is a utility function to exhaust the goroutine slots for testing purposes.
-func exhaustGoRoutines(ctx context.Context, fifoPath string) error {
 	// Reset the goroutine count before the test
 	atomic.StoreInt64(&goroutineCount, 0)
-
-	// Ensure the FIFO does not already exist
-	if _, err := os.Stat(fifoPath); err == nil {
-		os.Remove(fifoPath)
-	}
-
 	// Create a named pipe (FIFO)
-	if err := syscall.Mkfifo(fifoPath, 0666); err != nil {
-		return err
-	}
-
+	assert.NoError(t, syscall.Mkfifo(fifoPath, 0666))
 	// ReadFileContext for max go routines + 1 and wait for them to timeout,
 	// then check that the goroutine count is still at maxGoroutines.
 	var wg sync.WaitGroup
 	for range maxGoroutines + 1 {
 		wg.Go(func() {
-			readCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+			readCtx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 			defer cancel()
 			_, _ = ReadFileWithContext(readCtx, fifoPath)
 		})
 	}
 
 	wg.Wait()
-	return nil
+
+	assert.Equal(t, atomic.LoadInt64(&goroutineCount), int64(maxGoroutines))
+
+	// try to read once more, which should fail to reserve a slot
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err := ReadFileWithContext(ctx, fifoPath)
+	assert.NotEmpty(t, err)
+	assert.Equal(t, atomic.LoadInt64(&goroutineCount), int64(maxGoroutines))
 }

--- a/app/utils/files_test.go
+++ b/app/utils/files_test.go
@@ -47,7 +47,7 @@ func TestExhaustGoRoutinesPipeReads(t *testing.T) {
 	// try to read once more, which should fail to reserve a slot
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	_, err = ReadFileContext(ctx, fifoPath)
+	_, err = ReadFileWithContext(ctx, fifoPath)
 
 	if err == nil {
 		t.Fatalf("Expected ReadFileContext to fail due to exhausted goroutines, but it succeeded")
@@ -80,7 +80,7 @@ func exhaustGoRoutines(ctx context.Context, fifoPath string) error {
 		wg.Go(func() {
 			readCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
 			defer cancel()
-			_, _ = ReadFileContext(readCtx, fifoPath)
+			_, _ = ReadFileWithContext(readCtx, fifoPath)
 		})
 	}
 

--- a/app/utils/files_test.go
+++ b/app/utils/files_test.go
@@ -82,3 +82,53 @@ func TestExhaustGoRoutinesPipeReads(t *testing.T) {
 	assert.NotEmpty(t, err)
 	assert.Equal(t, atomic.LoadInt64(&goroutineCount), int64(maxGoroutines))
 }
+
+type HangingDirReader struct {
+	// Unblock allows controlled cleanup so the test goroutine doesn't leak indefinitely
+	Unblock chan struct{}
+}
+
+func (m *HangingDirReader) Readdirnames(n int) ([]string, error) {
+	<-m.Unblock // Blocks indefinitely until the channel is closed
+	return nil, context.DeadlineExceeded
+}
+
+func Test_FileTimeouts(t *testing.T) {
+
+	tests := []struct {
+		name string
+		fn   func(ctx context.Context, path string) error
+	}{
+		{
+			name: "ReadFileTimeout",
+			fn: func(ctx context.Context, path string) error {
+				_, err := ReadFileWithContext(ctx, path)
+				return err
+			}},
+		{
+			name: "ListDirectoryTimeout",
+			fn: func(ctx context.Context, path string) error {
+				_, err := ListDirectoryWithContext(ctx, path)
+				return err
+			}},
+	}
+
+	fifoPath := t.TempDir() + "/test_fifo"
+
+	assert.NoError(t, syscall.Mkfifo(fifoPath, 0666))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			atomic.StoreInt64(&goroutineCount, 0)
+
+			ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+			defer cancel()
+
+			err := tt.fn(ctx, fifoPath)
+			assert.True(t, errors.Is(err, context.DeadlineExceeded))
+
+			// Check that the goroutine count is 1 after the timeout occurred
+			assert.True(t, atomic.LoadInt64(&goroutineCount) == 1)
+		})
+	}
+}

--- a/app/utils/files_test.go
+++ b/app/utils/files_test.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"context"
+	"errors"
+	"os"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -27,6 +29,26 @@ func TestExhaustGoRoutines(t *testing.T) {
 
 	// Try to reserve one more slot, which should fail
 	assert.False(t, reserveGoroutineSlot())
+}
+
+func TestOpenFileWithContextClosesLateFile(t *testing.T) {
+	fifoPath := t.TempDir() + "/test_fifo"
+	atomic.StoreInt64(&goroutineCount, 0)
+	assert.NoError(t, syscall.Mkfifo(fifoPath, 0666))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := OpenFileWithContext(ctx, fifoPath)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+
+	writer, err := os.OpenFile(fifoPath, os.O_WRONLY, 0)
+	assert.NoError(t, err)
+	assert.NoError(t, writer.Close())
+
+	assert.EventuallyTrue(t, func() bool {
+		return atomic.LoadInt64(&goroutineCount) == 0
+	}, time.Second)
 }
 
 func TestExhaustGoRoutinesPipeReads(t *testing.T) {

--- a/app/utils/files_test.go
+++ b/app/utils/files_test.go
@@ -1,0 +1,81 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestExhaustGoRoutines(t *testing.T) {
+	// Reset the goroutine count before the test
+	atomic.StoreInt64(&goroutineCount, 0)
+
+	// Reserve the maximum number of goroutines
+	for i := range maxGoroutines {
+		if !reserveGoroutineSlot() {
+			t.Fatalf("Failed to reserve goroutine slot at iteration %d", i)
+		}
+	}
+
+	// Now, the goroutine count should be at maxGoroutines
+	if !GoroutinesExhausted() {
+		t.Fatalf("Expected GoroutinesExhausted to return true, but got false")
+	}
+
+	// Try to reserve one more slot, which should fail
+	if reserveGoroutineSlot() {
+		t.Fatalf("Expected reserveGoroutineSlot to return false when max goroutines reached, but got true")
+	}
+}
+
+func TestExhaustGoRoutinesPipeReads(t *testing.T) {
+	// Reset the goroutine count before the test
+	atomic.StoreInt64(&goroutineCount, 0)
+
+	// create a fifo
+
+	fifoPath := t.TempDir() + "/test_fifo"
+	// Ensure the FIFO does not already exist
+	if _, err := os.Stat(fifoPath); err == nil {
+		os.Remove(fifoPath)
+	}
+
+	// Create a named pipe (FIFO)
+	if err := syscall.Mkfifo(fifoPath, 0666); err != nil {
+		t.Fatalf("Failed to create FIFO: %v", err)
+	}
+
+	// ReadFileContext for max go routines + 1 and wait for them to timeout,
+	// then check that the goroutine count is still at maxGoroutines.
+	var wg sync.WaitGroup
+	for range maxGoroutines + 1 {
+		wg.Go(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+			_, _ = ReadFileContext(ctx, fifoPath)
+		})
+	}
+
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&goroutineCount); got != int64(maxGoroutines) {
+		t.Fatalf("Expected goroutine count to stay at maxGoroutines (%d), got %d", maxGoroutines, got)
+	}
+
+	// try to read once more, which should fail to reserve a slot
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := ReadFileContext(ctx, fifoPath)
+
+	if err == nil {
+		t.Fatalf("Expected ReadFileContext to fail due to exhausted goroutines, but it succeeded")
+	}
+
+	if got := atomic.LoadInt64(&goroutineCount); got != int64(maxGoroutines) {
+		t.Fatalf("Expected goroutine count to stay at maxGoroutines (%d) after additional read, got %d", maxGoroutines, got)
+	}
+}

--- a/app/utils/files_test.go
+++ b/app/utils/files_test.go
@@ -33,34 +33,12 @@ func TestExhaustGoRoutines(t *testing.T) {
 }
 
 func TestExhaustGoRoutinesPipeReads(t *testing.T) {
-	// Reset the goroutine count before the test
-	atomic.StoreInt64(&goroutineCount, 0)
-
-	// create a fifo
 
 	fifoPath := t.TempDir() + "/test_fifo"
-	// Ensure the FIFO does not already exist
-	if _, err := os.Stat(fifoPath); err == nil {
-		os.Remove(fifoPath)
+	err := exhaustGoRoutines(t.Context(), fifoPath)
+	if err != nil {
+		t.Fatalf("Failed to exhaust goroutines: %v", err)
 	}
-
-	// Create a named pipe (FIFO)
-	if err := syscall.Mkfifo(fifoPath, 0666); err != nil {
-		t.Fatalf("Failed to create FIFO: %v", err)
-	}
-
-	// ReadFileContext for max go routines + 1 and wait for them to timeout,
-	// then check that the goroutine count is still at maxGoroutines.
-	var wg sync.WaitGroup
-	for range maxGoroutines + 1 {
-		wg.Go(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-			defer cancel()
-			_, _ = ReadFileContext(ctx, fifoPath)
-		})
-	}
-
-	wg.Wait()
 
 	if got := atomic.LoadInt64(&goroutineCount); got != int64(maxGoroutines) {
 		t.Fatalf("Expected goroutine count to stay at maxGoroutines (%d), got %d", maxGoroutines, got)
@@ -69,7 +47,7 @@ func TestExhaustGoRoutinesPipeReads(t *testing.T) {
 	// try to read once more, which should fail to reserve a slot
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	_, err := ReadFileContext(ctx, fifoPath)
+	_, err = ReadFileContext(ctx, fifoPath)
 
 	if err == nil {
 		t.Fatalf("Expected ReadFileContext to fail due to exhausted goroutines, but it succeeded")
@@ -78,4 +56,34 @@ func TestExhaustGoRoutinesPipeReads(t *testing.T) {
 	if got := atomic.LoadInt64(&goroutineCount); got != int64(maxGoroutines) {
 		t.Fatalf("Expected goroutine count to stay at maxGoroutines (%d) after additional read, got %d", maxGoroutines, got)
 	}
+}
+
+// ExhaustGoRoutines is a utility function to exhaust the goroutine slots for testing purposes.
+func exhaustGoRoutines(ctx context.Context, fifoPath string) error {
+	// Reset the goroutine count before the test
+	atomic.StoreInt64(&goroutineCount, 0)
+
+	// Ensure the FIFO does not already exist
+	if _, err := os.Stat(fifoPath); err == nil {
+		os.Remove(fifoPath)
+	}
+
+	// Create a named pipe (FIFO)
+	if err := syscall.Mkfifo(fifoPath, 0666); err != nil {
+		return err
+	}
+
+	// ReadFileContext for max go routines + 1 and wait for them to timeout,
+	// then check that the goroutine count is still at maxGoroutines.
+	var wg sync.WaitGroup
+	for range maxGoroutines + 1 {
+		wg.Go(func() {
+			readCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+			defer cancel()
+			_, _ = ReadFileContext(readCtx, fifoPath)
+		})
+	}
+
+	wg.Wait()
+	return nil
 }

--- a/app/utils/parsers.go
+++ b/app/utils/parsers.go
@@ -23,8 +23,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // ForLines runs fn for every line in the provided io.Reader.
@@ -47,8 +49,34 @@ func ForLines(reader io.Reader, fn func(string) error) error {
 	return nil
 }
 
-// ForLinesInFile runs fn for every line in the provided filePath.
 func ForLinesInFile(filePath string, fn func(string) error) error {
+	if blockingFilePathsRE.MatchString(filePath) {
+		return forLinesInFileContext(filePath, fn)
+
+	}
+	return forLinesInFile(filePath, fn)
+}
+
+var blockingFilePathsRE = regexp.MustCompile(`^/proc/|^/sys/|^/dev/`)
+
+func forLinesInFileContext(filePath string, fn func(string) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	file, err := OpenFileContext(ctx, filePath)
+	if err != nil {
+		return fmt.Errorf("error opening file %s: %w", filePath, err)
+	}
+	defer func() {
+		if closer, ok := file.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
+
+	return ForLines(file, fn)
+}
+
+// ForLinesInFile runs fn for every line in the provided filePath.
+func forLinesInFile(filePath string, fn func(string) error) error {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("error opening file %s: %w", filePath, err)

--- a/app/utils/parsers.go
+++ b/app/utils/parsers.go
@@ -47,28 +47,26 @@ func ForLines(reader io.Reader, fn func(string) error) error {
 	return nil
 }
 
-// ForLinesInFile runs fn for every line in the provided filePath.
-func ForLinesInFile(filePath string, fn func(string) error) error {
-	if pathNeedsContextRead(filePath) {
-		ctx, cancel := context.WithTimeout(context.Background(), KernelVirtualFSReadTimeout)
-		defer cancel()
-
-		reader, err := OpenFileContext(ctx, filePath)
-		if err != nil {
-			return fmt.Errorf("error opening file %s: %w", filePath, err)
-		}
-
-		if closer, ok := reader.(io.Closer); ok {
-			defer func() { _ = closer.Close() }()
-		}
-
-		if err = ForLines(reader, fn); err != nil {
-			return fmt.Errorf("error processing file %s: %w", filePath, err)
-		}
-
-		return nil
+// ForLinesInFileWithContext runs fn for every line in the provided filePath with a context.
+func ForLinesInFileWithContext(ctx context.Context, filePath string, fn func(string) error) error {
+	reader, err := OpenFileWithContext(ctx, filePath)
+	if err != nil {
+		return fmt.Errorf("error opening file %s: %w", filePath, err)
 	}
 
+	if closer, ok := reader.(io.Closer); ok {
+		defer func() { _ = closer.Close() }()
+	}
+
+	if err = ForLines(reader, fn); err != nil {
+		return fmt.Errorf("error processing file %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
+// ForLinesInFile runs fn for every line in the provided filePath.
+func ForLinesInFile(filePath string, fn func(string) error) error {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("error opening file %s: %w", filePath, err)
@@ -81,12 +79,6 @@ func ForLinesInFile(filePath string, fn func(string) error) error {
 	}
 
 	return nil
-}
-
-func pathNeedsContextRead(filePath string) bool {
-	return filePath == "/proc" || strings.HasPrefix(filePath, "/proc/") ||
-		filePath == "/sys" || strings.HasPrefix(filePath, "/sys/") ||
-		filePath == "/dev" || strings.HasPrefix(filePath, "/dev/")
 }
 
 // ForLinesInCommandOutput executes a command and runs fn for each line of the stdout.

--- a/app/utils/parsers.go
+++ b/app/utils/parsers.go
@@ -49,16 +49,12 @@ func ForLines(reader io.Reader, fn func(string) error) error {
 
 // ForLinesInFileWithContext runs fn for every line in the provided filePath with a context.
 func ForLinesInFileWithContext(ctx context.Context, filePath string, fn func(string) error) error {
-	reader, err := OpenFileWithContext(ctx, filePath)
+	data, err := ReadFileWithContext(ctx, filePath)
 	if err != nil {
-		return fmt.Errorf("error opening file %s: %w", filePath, err)
+		return fmt.Errorf("error reading file %s: %w", filePath, err)
 	}
 
-	if closer, ok := reader.(io.Closer); ok {
-		defer func() { _ = closer.Close() }()
-	}
-
-	if err = ForLines(reader, fn); err != nil {
+	if err = ForLines(bytes.NewReader(data), fn); err != nil {
 		return fmt.Errorf("error processing file %s: %w", filePath, err)
 	}
 

--- a/app/utils/parsers.go
+++ b/app/utils/parsers.go
@@ -23,10 +23,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // ForLines runs fn for every line in the provided io.Reader.
@@ -49,34 +47,28 @@ func ForLines(reader io.Reader, fn func(string) error) error {
 	return nil
 }
 
-func ForLinesInFile(filePath string, fn func(string) error) error {
-	if blockingFilePathsRE.MatchString(filePath) {
-		return forLinesInFileContext(filePath, fn)
-
-	}
-	return forLinesInFile(filePath, fn)
-}
-
-var blockingFilePathsRE = regexp.MustCompile(`^/proc/|^/sys/|^/dev/`)
-
-func forLinesInFileContext(filePath string, fn func(string) error) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	file, err := OpenFileContext(ctx, filePath)
-	if err != nil {
-		return fmt.Errorf("error opening file %s: %w", filePath, err)
-	}
-	defer func() {
-		if closer, ok := file.(io.Closer); ok {
-			_ = closer.Close()
-		}
-	}()
-
-	return ForLines(file, fn)
-}
-
 // ForLinesInFile runs fn for every line in the provided filePath.
-func forLinesInFile(filePath string, fn func(string) error) error {
+func ForLinesInFile(filePath string, fn func(string) error) error {
+	if pathNeedsContextRead(filePath) {
+		ctx, cancel := context.WithTimeout(context.Background(), KernelVirtualFSReadTimeout)
+		defer cancel()
+
+		reader, err := OpenFileContext(ctx, filePath)
+		if err != nil {
+			return fmt.Errorf("error opening file %s: %w", filePath, err)
+		}
+
+		if closer, ok := reader.(io.Closer); ok {
+			defer func() { _ = closer.Close() }()
+		}
+
+		if err = ForLines(reader, fn); err != nil {
+			return fmt.Errorf("error processing file %s: %w", filePath, err)
+		}
+
+		return nil
+	}
+
 	file, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("error opening file %s: %w", filePath, err)
@@ -89,6 +81,12 @@ func forLinesInFile(filePath string, fn func(string) error) error {
 	}
 
 	return nil
+}
+
+func pathNeedsContextRead(filePath string) bool {
+	return filePath == "/proc" || strings.HasPrefix(filePath, "/proc/") ||
+		filePath == "/sys" || strings.HasPrefix(filePath, "/sys/") ||
+		filePath == "/dev" || strings.HasPrefix(filePath, "/dev/")
 }
 
 // ForLinesInCommandOutput executes a command and runs fn for each line of the stdout.

--- a/app/utils/parsers.go
+++ b/app/utils/parsers.go
@@ -33,15 +33,15 @@ func ForLines(reader io.Reader, fn func(string) error) error {
 
 	var lineNumber uint64
 	for scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("error reading line: %w", err)
-		}
-
 		lineNumber++
 
 		if err := fn(scanner.Text()); err != nil {
 			return fmt.Errorf("error processing line %d: %w", lineNumber, err)
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading line: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This pull request refactors several inventory and metrics collection functions to accept a `context.Context` parameter, enabling better control over timeouts and cancellations, especially when reading from kernel virtual filesystems. It also introduces a mechanism to detect and handle exhausted goroutine budgets, reporting this condition and skipping agent runs when necessary. Additionally, related tests and function calls throughout the codebase have been updated to use the new context-aware signatures.

**Inventory and Metrics Collection Improvements:**

* Refactored inventory collection functions such as `CollectSystemInventory`, `CollectPortsInventory`, and `CollectProcessesInventory` (and their usages) to accept a `context.Context` parameter, allowing for timeout and cancellation support when reading from system files. This includes changes in both agent logic and CLI commands. [[1]](diffhunk://#diff-acf73a5f3f07d19ea4ae2c6f9cb68eecac2b5155c9d9886f7a057ab2d67d3242L145-R148) [[2]](diffhunk://#diff-c06dc4e0048e63b642511f2338f2abad190a5dc4b54c4059566ae4681f904767L64-R64) [[3]](diffhunk://#diff-c06dc4e0048e63b642511f2338f2abad190a5dc4b54c4059566ae4681f904767L90-R90) [[4]](diffhunk://#diff-c06dc4e0048e63b642511f2338f2abad190a5dc4b54c4059566ae4681f904767L199-R199) [[5]](diffhunk://#diff-edfcdffd373dc476c10a7428b3739c3e2cce663afd0406877bc2a8e972b850a5L71-R75) [[6]](diffhunk://#diff-b2d3118f3730a16c163d5446dcf2d3437d75d253553057a851a49a8e3df8affdL97-R139) [[7]](diffhunk://#diff-d48f6a77378599b16d16608627e8740b3eeee9260eaef023e2fc994d829f6ef7L57-R57)
* Updated metrics collection methods (`metrics.Collect`) and related test cases to require a context, ensuring consistent context propagation for all metrics gathering operations. [[1]](diffhunk://#diff-fe8f4a8975ee160e38bb2753fe91a446dd389dd25c8e12e1f42e5259a855d685L93-R93) [[2]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L77-R77) [[3]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L86-R86) [[4]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L109-R109) [[5]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L127-R127) [[6]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L136-L142) [[7]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L157-R150) [[8]](diffhunk://#diff-6fd0853988157e347f8787a4ecc15581c31ef4c6cc21600ed3678846b81ee28eL204-R213)
* Modified low-level Linux inventory helpers (`GetMemInfo`, `GetProcessStatus`, `ListRunningProcesses`, `ListRunningProcessesNames`, and `GetProcessCommand`) to accept a context and use timeouts when reading from `/proc`, improving reliability and responsiveness. [[1]](diffhunk://#diff-ec89597e34d37581c5338db14f98ea269503bd468f9c5e8e1bd508ca1c31dd22R22) [[2]](diffhunk://#diff-ec89597e34d37581c5338db14f98ea269503bd468f9c5e8e1bd508ca1c31dd22L41-R50) [[3]](diffhunk://#diff-50ac68116724d55357dc21c74040c71362e02436beb63385bbd418e8598dec53R22) [[4]](diffhunk://#diff-50ac68116724d55357dc21c74040c71362e02436beb63385bbd418e8598dec53L39-R47) [[5]](diffhunk://#diff-cd2dd05502ab1e9df9ff593bdc9491f52f466e75e6f20dce167d467321334365R22-R36) [[6]](diffhunk://#diff-cd2dd05502ab1e9df9ff593bdc9491f52f466e75e6f20dce167d467321334365L51-R56) [[7]](diffhunk://#diff-cd2dd05502ab1e9df9ff593bdc9491f52f466e75e6f20dce167d467321334365L62-R66)

**Goroutine Budget Exhaustion Handling:**

* Added a new method `ReportExhaustedGoroutineBudget` to the `Service` struct, which reports an error and skips the agent run if the goroutine budget is exhausted. This includes immediate reporting and buffering of reports if sending fails, as well as a dedicated test for this logic. [[1]](diffhunk://#diff-c63f39254f9b47933133572971041023b6e3a071fdfd1a59b605c37503df1134R332-R362) [[2]](diffhunk://#diff-2fe7ac568ac22100a6ccfaa56fcc6bc48642c51d5820c37c5e16a5b09e29ab73R220-R249) [[3]](diffhunk://#diff-6fd0853988157e347f8787a4ecc15581c31ef4c6cc21600ed3678846b81ee28eR176-R184)
* Introduced an internal bundle identifier `bundleAgentInternal` for internal agent reporting.

**Miscellaneous:**

* Updated all relevant function calls and tests to use the new context-aware interfaces, ensuring consistency across the codebase. [[1]](diffhunk://#diff-efedf03a0b64d4113f4543c6b6614275bbc1e311f8b8124a67a5f97c7504d701L54-R54) [[2]](diffhunk://#diff-c63f39254f9b47933133572971041023b6e3a071fdfd1a59b605c37503df1134R33) [[3]](diffhunk://#diff-2fe7ac568ac22100a6ccfaa56fcc6bc48642c51d5820c37c5e16a5b09e29ab73R33)

These changes improve the robustness and observability of the agent, especially under resource constraints and in environments where system file access may be slow or unreliable.