### PR TITLE
DEV-2788: Non-blocking reads kernel fs

### DIFF
--- a/app/agent/agent.go
+++ b/app/agent/agent.go
@@ -173,6 +173,15 @@ func (agent *Agent) RunOnce(ctx context.Context, mode RunOnceMode) {
 	agent.Configuration.UpdateSettings(configData)
 	agent.Configuration.UpdateMetricsMonitorState(configData)
 
+	// Check if we have enough goroutine budget to run the agent, if not, skip the run.
+	// Do this after we have updated the configuration, so that the device is online.
+	if exhausted, err := agent.Configuration.ReportExhaustedGoroutineBudget(ctx); exhausted {
+		if err != nil {
+			log.Errorf("failed to report goroutine budget: %v", err)
+		}
+		return
+	}
+
 	if mode == FullRun {
 		agent.do(ctx, "check-in", agent.checkIn)
 		agent.do(ctx, "remote-access", agent.doRemoteAccess(configData))
@@ -201,7 +210,7 @@ func (agent *Agent) doMetrics(ctx context.Context) error {
 		return nil
 	}
 
-	if err := agent.Metrics.Send(ctx, agent.Metrics.Collect()); err != nil {
+	if err := agent.Metrics.Send(ctx, agent.Metrics.Collect(ctx)); err != nil {
 		return fmt.Errorf("failed to send metrics: %w", err)
 	}
 

--- a/app/agent/bootstrap.go
+++ b/app/agent/bootstrap.go
@@ -58,7 +58,7 @@ func Bootstrap(ctx context.Context, cfg *Config) error {
 	}
 
 	var bootstrapRequest *BootstrapRequest
-	bootstrapRequest, err = agent.newBootstrapRequest()
+	bootstrapRequest, err = agent.newBootstrapRequest(ctx)
 	if err != nil {
 		return err
 	}
@@ -142,10 +142,10 @@ func (agent *Agent) getRawPublicKey() ([]string, error) {
 }
 
 // newBootstrapRequest returns a new BootstrapRequest for the agent.
-func (agent *Agent) newBootstrapRequest() (*BootstrapRequest, error) {
+func (agent *Agent) newBootstrapRequest(ctx context.Context) (*BootstrapRequest, error) {
 	log.Infof("Gathering system information")
 
-	systemInventory, err := inventory.CollectSystemInventory(agent.IsTPMEnabled())
+	systemInventory, err := inventory.CollectSystemInventory(ctx, agent.IsTPMEnabled())
 	if err != nil {
 		return nil, fmt.Errorf("error collecting system info: %w", err)
 	}

--- a/app/agent/inventory.go
+++ b/app/agent/inventory.go
@@ -61,7 +61,7 @@ func (agent *Agent) doInventories(ctx context.Context) error {
 
 // doSystemInventory collects system inventory and delivers it to the device hub API.
 func (agent *Agent) doSystemInventory(ctx context.Context) error {
-	systemInventory, err := inventory.CollectSystemInventory(agent.IsTPMEnabled())
+	systemInventory, err := inventory.CollectSystemInventory(ctx, agent.IsTPMEnabled())
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (agent *Agent) doUsersInventory(ctx context.Context) error {
 
 // doPortsInventory collects ports inventory and delivers it to the device hub API.
 func (agent *Agent) doPortsInventory(ctx context.Context) error {
-	portsInventory, err := inventory.CollectPortsInventory()
+	portsInventory, err := inventory.CollectPortsInventory(ctx)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func (agent *Agent) doProcessInventory(ctx context.Context) error {
 		return nil
 	}
 
-	processesInventory, err := inventory.CollectProcessesInventory()
+	processesInventory, err := inventory.CollectProcessesInventory(ctx)
 	if err != nil {
 		return err
 	}

--- a/app/cmd/inventory.go
+++ b/app/cmd/inventory.go
@@ -68,11 +68,11 @@ var inventoryCommand = cmd.Command{
 
 		switch inventoryType {
 		case inventory.TypeSystem:
-			inventoryData, err = inventory.CollectSystemInventory(cfg.TPMDevice != "")
+			inventoryData, err = inventory.CollectSystemInventory(ctx, cfg.TPMDevice != "")
 		case inventory.TypePorts:
-			inventoryData, err = inventory.CollectPortsInventory()
+			inventoryData, err = inventory.CollectPortsInventory(ctx)
 		case inventory.TypeProcesses:
-			inventoryData, err = inventory.CollectProcessesInventory()
+			inventoryData, err = inventory.CollectProcessesInventory(ctx)
 		case inventory.TypeUsers:
 			inventoryData, err = inventory.CollectUsersInventory()
 		case inventory.TypeSoftware:

--- a/app/configuration/bundle_metrics_monitor.go
+++ b/app/configuration/bundle_metrics_monitor.go
@@ -90,7 +90,7 @@ func init() {
 // Execute the metrics monitor bundle.
 func (m *MetricsMonitorBundle) Execute(ctx context.Context, service *Service) error {
 
-	collectedMetrics := service.metrics.Collect()
+	collectedMetrics := service.metrics.Collect(ctx)
 
 	reports, err := m.EvaluateMonitors(collectedMetrics)
 	if err != nil {

--- a/app/configuration/bundle_metrics_monitor_test.go
+++ b/app/configuration/bundle_metrics_monitor_test.go
@@ -74,7 +74,7 @@ func Test_Monitor_State_Set(t *testing.T) {
 	}
 
 	metricsService := metrics.New(nil)
-	collectedMetrics := metricsService.Collect()
+	collectedMetrics := metricsService.Collect(t.Context())
 	reports, err := metricsMonitorBundle.EvaluateMonitors(collectedMetrics)
 
 	if err != nil {
@@ -83,7 +83,7 @@ func Test_Monitor_State_Set(t *testing.T) {
 
 	assert.Equal(t, len(reports), 1)
 
-	collectedMetrics = metricsService.Collect()
+	collectedMetrics = metricsService.Collect(t.Context())
 	reports, err = metricsMonitorBundle.EvaluateMonitors(collectedMetrics)
 
 	if err != nil {
@@ -106,7 +106,7 @@ func Test_Monitor_State_Reset(t *testing.T) {
 	}
 
 	metricsService := metrics.New(nil)
-	collectedMetrics := metricsService.Collect()
+	collectedMetrics := metricsService.Collect(t.Context())
 	reports, err := metricsMonitorBundle.EvaluateMonitors(collectedMetrics)
 
 	if err != nil {
@@ -124,7 +124,7 @@ func Test_Monitor_State_Reset(t *testing.T) {
 		},
 	}
 
-	collectedMetrics = metricsService.Collect()
+	collectedMetrics = metricsService.Collect(t.Context())
 	reports, err = metricsMonitorBundle.EvaluateMonitors(collectedMetrics)
 
 	if err != nil {
@@ -133,13 +133,6 @@ func Test_Monitor_State_Reset(t *testing.T) {
 
 	// Monitor has changed value, we should get a new report
 	assert.Equal(t, len(reports), 1)
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	assert.Equal(t, len(reports), 1)
-
 }
 
 func Test_Monitor_State_Delete(t *testing.T) {
@@ -154,7 +147,7 @@ func Test_Monitor_State_Delete(t *testing.T) {
 	}
 
 	metricsService := metrics.New(nil)
-	collectedMetrics := metricsService.Collect()
+	collectedMetrics := metricsService.Collect(t.Context())
 	reports, err := metricsMonitorBundle.EvaluateMonitors(collectedMetrics)
 
 	if err != nil {

--- a/app/configuration/bundle_parameters.go
+++ b/app/configuration/bundle_parameters.go
@@ -94,49 +94,49 @@ var systemParameters = map[string]func(ctx context.Context) (string, error){
 		return string(software.DefaultPackageManager.Type()), nil
 	},
 	"sys.os": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.OS, nil
 	},
 	"sys.arch": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.Architecture, nil
 	},
 	"sys.os_type": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.OSType, nil
 	},
 	"sys.flavor": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.Flavor, nil
 	},
 	"sys.agent_version": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.AgentVersion, nil
 	},
 	"sys.long_arch": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}
 		return systemInventory.System.LongArchitecture, nil
 	},
 	"sys.boot_time": func(ctx context.Context) (string, error) {
-		systemInventory, err := inventory.CollectSystemInventory(false)
+		systemInventory, err := inventory.CollectSystemInventory(ctx, false)
 		if err != nil {
 			return "", err
 		}

--- a/app/configuration/bundle_parameters_test.go
+++ b/app/configuration/bundle_parameters_test.go
@@ -54,7 +54,7 @@ func Test_resolveParameters(t *testing.T) {
 
 	pkgType := software.DefaultPackageManager.Type()
 
-	systemInventory, err := inventory.CollectSystemInventory(false)
+	systemInventory, err := inventory.CollectSystemInventory(t.Context(), false)
 	assert.NoError(t, err)
 
 	invSystem := systemInventory.System

--- a/app/configuration/bundle_process_watch.go
+++ b/app/configuration/bundle_process_watch.go
@@ -51,7 +51,7 @@ type ProcessWatchBundle struct {
 
 // Execute ensures that watched processes are in a correct state.
 func (p ProcessWatchBundle) Execute(ctx context.Context, _ *Service) error {
-	runningProcesses, err := linux.ListRunningProcessesNames()
+	runningProcesses, err := linux.ListRunningProcessesNames(ctx)
 	if err != nil {
 		return fmt.Errorf("cannot list running processes: %w", err)
 	}

--- a/app/configuration/config.go
+++ b/app/configuration/config.go
@@ -37,6 +37,9 @@ const (
 	BundleRauc                 = "rauc"
 	BundleMetricsMonitor       = "metrics_monitor"
 	BundleDockerCompose        = "docker_compose"
+
+	// used to send an agent report to the DeviceHub on internal events (eg. goroutine budget exhaustion)
+	bundleAgentInternal = "agent_internal"
 )
 
 // CommittedConfig contains the configuration that is committed.

--- a/app/configuration/report.go
+++ b/app/configuration/report.go
@@ -109,9 +109,10 @@ func NewReporter(commitID string, reportToConsole bool, secrets []string) *Repor
 }
 
 const (
-	severityInfo    = "INFO"
-	severityWarning = "WARN"
-	severityError   = "ERR"
+	severityInfo     = "INFO"
+	severityWarning  = "WARN"
+	severityError    = "ERR"
+	severityCritical = "CRIT"
 )
 
 // msgWithLabel returns a message with a label (if provided).
@@ -141,6 +142,11 @@ func ReportError(ctx context.Context, extraLog any, msgFmt string, args ...any) 
 	}
 
 	addReport(ctx, severityError, extraLog, msgFmt, args...)
+}
+
+// ReportCritical adds a critical message to the reporter instance set in context.
+func ReportCritical(ctx context.Context, extraLog any, msgFmt string, args ...any) {
+	addReport(ctx, severityCritical, extraLog, msgFmt, args...)
 }
 
 const (

--- a/app/configuration/service.go
+++ b/app/configuration/service.go
@@ -30,6 +30,7 @@ import (
 	"go.qbee.io/agent/app/api"
 	"go.qbee.io/agent/app/log"
 	"go.qbee.io/agent/app/metrics"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 const defaultAgentInterval = 5 // minutes
@@ -326,6 +327,39 @@ func (srv *Service) reportAPIError(ctx context.Context, err error) {
 			log.Errorf("failed to add reports to buffer: %v", err)
 		}
 	}
+}
+
+// ReportExhaustedGoroutineBudget reports when the goroutine budget is exhausted and returns whether the
+// budget was exhausted and any error encountered delivering the report.
+func (srv *Service) ReportExhaustedGoroutineBudget(ctx context.Context) (bool, error) {
+	if !files.GoroutinesExhausted() {
+		return false, nil
+	}
+
+	// since we don't have a reporter defined on this context, we need to create a new one
+	reporter := NewReporter(srv.currentCommitID, srv.reportToConsole, nil)
+	bundleCtx := reporter.BundleContext(ctx, bundleAgentInternal, "")
+
+	ReportError(bundleCtx, nil, "goroutine budget exhausted, skipping agent run")
+
+	// send reports immediately as there will be no further configurations executed, thus
+	// no further reports will be generated. If we fail to send the reports, we add them to the buffer.
+	if _, err := srv.sendReports(ctx, reporter.Reports()); err != nil {
+		log.Debugf("failed to send reports to the server: %v, adding to the buffer", err)
+
+		if bufferErr := srv.addReportsToBuffer(reporter.Reports()); bufferErr != nil {
+			log.Errorf("failed to add reports to buffer: %v", bufferErr)
+		}
+
+		return true, err
+	}
+
+	// also flush any existing buffered reports
+	if err := srv.flushReportsBuffer(ctx); err != nil {
+		log.Errorf("failed to flush reports buffer: %v", err)
+	}
+
+	return true, nil
 }
 
 // RunIntervalChangedNotifier returns a channel which will send a new agent interval duration when it changes.

--- a/app/configuration/service.go
+++ b/app/configuration/service.go
@@ -340,7 +340,7 @@ func (srv *Service) ReportExhaustedGoroutineBudget(ctx context.Context) (bool, e
 	reporter := NewReporter(srv.currentCommitID, srv.reportToConsole, nil)
 	bundleCtx := reporter.BundleContext(ctx, bundleAgentInternal, "")
 
-	ReportError(bundleCtx, nil, "goroutine budget exhausted, skipping agent run")
+	ReportCritical(bundleCtx, nil, "goroutine budget exhausted, skipping agent run")
 
 	// send reports immediately as there will be no further configurations executed, thus
 	// no further reports will be generated. If we fail to send the reports, we add them to the buffer.

--- a/app/configuration/service_test.go
+++ b/app/configuration/service_test.go
@@ -31,6 +31,7 @@ import (
 
 	"go.qbee.io/agent/app/api"
 	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 func TestService_reportsBuffer(t *testing.T) {
@@ -215,4 +216,34 @@ func Test_ConfigEndpointBooleanReset(t *testing.T) {
 	if srv.IsConfigEndpointUnreachable() {
 		t.Fatalf("expected config endpoint to be reachable")
 	}
+}
+
+func TestService_ReportExhaustedGoroutineBudget(t *testing.T) {
+	tmpDir := t.TempDir()
+	srv := New(nil, tmpDir, "")
+	srv.currentCommitID = "test-commit-id"
+
+	// Create a mock API client that will fail to send reports
+	// so they get buffered to the reports file
+	mockClient := api.NewClient("localhost", "99999")
+	srv.api = mockClient
+
+	// Simulate exhausted goroutine budget
+	files.SetGoroutineCountForTesting(500)     // maxGoroutines is 500
+	defer files.SetGoroutineCountForTesting(0) // reset after test
+
+	// Call ReportExhaustedGoroutineBudget
+	exhausted, _ := srv.ReportExhaustedGoroutineBudget(context.Background())
+
+	// Verify that it returns true (indicating budget was exhausted)
+	assert.True(t, exhausted)
+
+	// Read the buffered reports
+	reports, readErr := srv.readReportsBuffer()
+	assert.NoError(t, readErr)
+	assert.NotEqual(t, len(reports), 0)
+
+	assert.Equal(t, reports[0].Bundle, bundleAgentInternal)
+	assert.Equal(t, reports[0].Severity, severityError)
+	assert.Equal(t, reports[0].Text, "goroutine budget exhausted, skipping agent run")
 }

--- a/app/configuration/service_test.go
+++ b/app/configuration/service_test.go
@@ -244,6 +244,6 @@ func TestService_ReportExhaustedGoroutineBudget(t *testing.T) {
 	assert.NotEqual(t, len(reports), 0)
 
 	assert.Equal(t, reports[0].Bundle, bundleAgentInternal)
-	assert.Equal(t, reports[0].Severity, severityError)
+	assert.Equal(t, reports[0].Severity, severityCritical)
 	assert.Equal(t, reports[0].Text, "goroutine budget exhausted, skipping agent run")
 }

--- a/app/inventory/linux/mem_info.go
+++ b/app/inventory/linux/mem_info.go
@@ -19,12 +19,13 @@
 package linux
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
 
-	"go.qbee.io/agent/app/utils"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // MemInfo provides basic information about system memory.
@@ -38,12 +39,12 @@ type MemInfo struct {
 }
 
 // GetMemInfo returns basic memory information from the system.
-func GetMemInfo() (*MemInfo, error) {
+func GetMemInfo(ctx context.Context) (*MemInfo, error) {
 	filePath := filepath.Join(ProcFS, "meminfo")
 
 	memInfo := new(MemInfo)
 
-	err := utils.ForLinesInFile(filePath, func(line string) error {
+	err := files.ForLinesInFile(ctx, files.KernelVirtualFSReadTimeout, filePath, func(line string) error {
 		var err error
 
 		fields := strings.Fields(line)

--- a/app/inventory/linux/process_status.go
+++ b/app/inventory/linux/process_status.go
@@ -19,13 +19,14 @@
 package linux
 
 import (
+	"context"
 	"fmt"
 	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
 
-	"go.qbee.io/agent/app/utils"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // ProcessStatus contains information about a process.
@@ -36,11 +37,11 @@ type ProcessStatus struct {
 
 // GetProcessStatus returns ProcessStatus based on /proc/*/status.
 // See `man proc` -> `/proc/[pid]/status section for details on the file format.
-func GetProcessStatus(pid string) (*ProcessStatus, error) {
+func GetProcessStatus(ctx context.Context, pid string) (*ProcessStatus, error) {
 	statusFilePath := filepath.Join(ProcFS, pid, "status")
 	processStatus := new(ProcessStatus)
 
-	err := utils.ForLinesInFile(statusFilePath, func(line string) error {
+	err := files.ForLinesInFile(ctx, files.KernelVirtualFSReadTimeout, statusFilePath, func(line string) error {
 		fields := strings.Fields(line)
 
 		switch fields[0] {

--- a/app/inventory/linux/running_processes.go
+++ b/app/inventory/linux/running_processes.go
@@ -19,17 +19,17 @@
 package linux
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
-	"go.qbee.io/agent/app/utils"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // ListRunningProcesses returns a list of PIDs of currently running processes.
-func ListRunningProcesses() ([]string, error) {
-	dirNames, err := utils.ListDirectory(ProcFS)
+func ListRunningProcesses(ctx context.Context) ([]string, error) {
+	dirNames, err := files.ListDirectory(ctx, files.KernelVirtualFSReadTimeout, ProcFS)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +48,8 @@ func ListRunningProcesses() ([]string, error) {
 }
 
 // ListRunningProcessesNames returns a map of running process PID -> process command-line.
-func ListRunningProcessesNames() (map[string]string, error) {
-	runningProcesses, err := ListRunningProcesses()
+func ListRunningProcessesNames(ctx context.Context) (map[string]string, error) {
+	runningProcesses, err := ListRunningProcesses(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func ListRunningProcessesNames() (map[string]string, error) {
 	for _, pid := range runningProcesses {
 		var cmdLine string
 
-		if cmdLine, err = GetProcessCommand(pid); err != nil {
+		if cmdLine, err = GetProcessCommand(ctx, pid); err != nil {
 			return nil, err
 		}
 
@@ -70,10 +70,10 @@ func ListRunningProcessesNames() (map[string]string, error) {
 }
 
 // GetProcessCommand returns a command used to start the process.
-func GetProcessCommand(pid string) (string, error) {
+func GetProcessCommand(ctx context.Context, pid string) (string, error) {
 	cmdLinePath := filepath.Join(ProcFS, pid, "cmdline")
 
-	cmdLineBytes, err := os.ReadFile(cmdLinePath)
+	cmdLineBytes, err := files.ReadAll(ctx, files.KernelVirtualFSReadTimeout, cmdLinePath)
 	if err != nil {
 		return "", fmt.Errorf("error reading %s: %w", cmdLinePath, err)
 	}

--- a/app/inventory/ports_linux.go
+++ b/app/inventory/ports_linux.go
@@ -19,6 +19,7 @@
 package inventory
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -32,23 +33,23 @@ import (
 
 	"go.qbee.io/agent/app/inventory/linux"
 	"go.qbee.io/agent/app/log"
-	"go.qbee.io/agent/app/utils"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // CollectPortsInventory returns populated Ports inventory based on current system status.
-func CollectPortsInventory() (*Ports, error) {
+func CollectPortsInventory(ctx context.Context) (*Ports, error) {
 	ports := new(Ports)
 
 	var protocols = []string{"tcp", "tcp6", "udp", "udp6"}
 
-	inodesMap, err := loadProcessFDInodes()
+	inodesMap, err := loadProcessFDInodes(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, protocol := range protocols {
 		var listeningPorts []Port
-		if listeningPorts, err = parseNetworkPorts(protocol, inodesMap); err != nil {
+		if listeningPorts, err = parseNetworkPorts(ctx, protocol, inodesMap); err != nil {
 			return nil, err
 		}
 
@@ -61,9 +62,9 @@ func CollectPortsInventory() (*Ports, error) {
 }
 
 // loadProcessFDInodes loads mapping of processes' open files inodes to file paths.
-func loadProcessFDInodes() (map[uint64]string, error) {
+func loadProcessFDInodes(ctx context.Context) (map[uint64]string, error) {
 	// scan all open files for all running processes
-	runningProcesses, err := linux.ListRunningProcesses()
+	runningProcesses, err := linux.ListRunningProcesses(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot list currently running processes: %w", err)
 	}
@@ -79,7 +80,7 @@ func loadProcessFDInodes() (map[uint64]string, error) {
 		processProcPath := filepath.Join(linux.ProcFS, pid)
 		fdDirPath := filepath.Join(processProcPath, "fd")
 
-		fdPaths, err = utils.ListDirectory(fdDirPath)
+		fdPaths, err = files.ListDirectory(ctx, files.KernelVirtualFSReadTimeout, fdDirPath)
 		if err != nil {
 			log.Debugf("cannot list inodes for process %s: %v", pid, err)
 			continue
@@ -88,8 +89,10 @@ func loadProcessFDInodes() (map[uint64]string, error) {
 		for _, relativeFDPath := range fdPaths {
 			fdPath := filepath.Join(fdDirPath, relativeFDPath)
 
+			fileStat, err = files.Stat(ctx, files.KernelVirtualFSReadTimeout, fdPath)
+
 			// get file info for each open file
-			if fileStat, err = os.Stat(fdPath); err != nil {
+			if err != nil {
 				// Silence debug messages for the agent PID, since it's always producing an error.
 				// The error is due to the agent closing the directory's file description (in utils.ListDirectory)
 				// before we get to read all the files' inodes.
@@ -109,11 +112,11 @@ func loadProcessFDInodes() (map[uint64]string, error) {
 }
 
 // parseNetworkPorts parses /proc/net/<protocol> file format and returns a list of listening ports.
-func parseNetworkPorts(protocol string, inodesMap map[uint64]string) ([]Port, error) {
+func parseNetworkPorts(ctx context.Context, protocol string, inodesMap map[uint64]string) ([]Port, error) {
 	procFilePath := filepath.Join("/proc/net", protocol)
 	ports := make([]Port, 0)
 
-	err := utils.ForLinesInFile(procFilePath, func(line string) error {
+	err := files.ForLinesInFile(ctx, files.KernelVirtualFSReadTimeout, procFilePath, func(line string) error {
 		fields := strings.Fields(line)
 
 		// Skip non-listening sockets (that also skips the header).
@@ -139,7 +142,7 @@ func parseNetworkPorts(protocol string, inodesMap map[uint64]string) ([]Port, er
 		if fileDescriptorPath, found := inodesMap[uint64(inodeInt)]; found {
 			processID := strings.SplitN(fileDescriptorPath, "/", 4)[2]
 
-			if cmdLine, err = linux.GetProcessCommand(processID); err != nil {
+			if cmdLine, err = linux.GetProcessCommand(ctx, processID); err != nil {
 				return err
 			}
 		}

--- a/app/inventory/ports_linux_test.go
+++ b/app/inventory/ports_linux_test.go
@@ -20,10 +20,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 func TestCollectPortsInventory(t *testing.T) {
-	ports, err := CollectPortsInventory()
+	ports, err := CollectPortsInventory(t.Context())
 	if err != nil {
 		t.Fatalf("error collecting ports: %v", err)
 	}
@@ -31,4 +34,7 @@ func TestCollectPortsInventory(t *testing.T) {
 	data, _ := json.MarshalIndent(ports, " ", " ")
 
 	fmt.Println(string(data))
+
+	// make sure that the goroutine count is back to its original value before collection
+	assert.Equal(t, files.GetGoroutineCount(), int64(0))
 }

--- a/app/inventory/processes_linux.go
+++ b/app/inventory/processes_linux.go
@@ -20,10 +20,10 @@ package inventory
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -31,12 +31,13 @@ import (
 	"time"
 
 	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // CollectProcessesInventory returns populated Processes inventory based on current system status.
 // Based on https://www.kernel.org/doc/html/latest/filesystems/proc.html#id10
-func CollectProcessesInventory() (*Processes, error) {
-	runningProcesses, err := linux.ListRunningProcesses()
+func CollectProcessesInventory(ctx context.Context) (*Processes, error) {
+	runningProcesses, err := linux.ListRunningProcesses(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error listing running processes: %w", err)
 	}
@@ -47,12 +48,12 @@ func CollectProcessesInventory() (*Processes, error) {
 	firstReadTime := time.Now()
 
 	// collect total CPU jiffies
-	if totalJiffiesT0, err = getTotalJiffies(); err != nil {
+	if totalJiffiesT0, err = getTotalJiffies(ctx); err != nil {
 		return nil, err
 	}
 
 	// collect CPU stats for each process
-	if processJiffiesT0, err = getProcessStats(runningProcesses); err != nil {
+	if processJiffiesT0, err = getProcessStats(ctx, runningProcesses); err != nil {
 		return nil, err
 	}
 
@@ -62,18 +63,18 @@ func CollectProcessesInventory() (*Processes, error) {
 	time.Sleep(time.Second - time.Since(firstReadTime))
 
 	// collect total CPU jiffies (again)
-	if totalJiffiesT1, err = getTotalJiffies(); err != nil {
+	if totalJiffiesT1, err = getTotalJiffies(ctx); err != nil {
 		return nil, err
 	}
 
 	// collect CPU stats for each process (again)
-	if processJiffiesT1, err = getProcessStats(runningProcesses); err != nil {
+	if processJiffiesT1, err = getProcessStats(ctx, runningProcesses); err != nil {
 		return nil, err
 	}
 
 	// get system memory information
 	var memInfo *linux.MemInfo
-	if memInfo, err = linux.GetMemInfo(); err != nil {
+	if memInfo, err = linux.GetMemInfo(ctx); err != nil {
 		return nil, err
 	}
 
@@ -104,7 +105,7 @@ func CollectProcessesInventory() (*Processes, error) {
 		jiffiesDelta := jiffiesT1 - jiffiesT0
 
 		// get process status
-		if processStatus, err = linux.GetProcessStatus(pid); err != nil {
+		if processStatus, err = linux.GetProcessStatus(ctx, pid); err != nil {
 			// if process is gone, skip it
 			if errors.Is(err, fs.ErrNotExist) {
 				continue
@@ -130,39 +131,25 @@ func CollectProcessesInventory() (*Processes, error) {
 const procStatBufferSize = 1024
 
 // getProcessStats returns a map of PID -> process stats for currently running processes.
-func getProcessStats(runningProcesses []string) (map[string]linux.ProcessStats, error) {
+func getProcessStats(ctx context.Context, runningProcesses []string) (map[string]linux.ProcessStats, error) {
 	processStats := make(map[string]linux.ProcessStats)
 
-	var n int
 	var err error
-	var procStatFile *os.File
-	var statFilePath string
-
-	buf := make([]byte, procStatBufferSize)
 
 	for _, pid := range runningProcesses {
-		statFilePath = filepath.Join(linux.ProcFS, pid, "stat")
+		statFilePath := filepath.Join(linux.ProcFS, pid, "stat")
 
-		if procStatFile, err = os.Open(statFilePath); err != nil {
+		data, readErr := files.Read(ctx, files.KernelVirtualFSReadTimeout, procStatBufferSize, statFilePath)
+		if readErr != nil {
+			err = readErr
 			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
 
-			return nil, fmt.Errorf("error opening %s: %w", statFilePath, err)
-		}
-
-		// read file contents to a buffer
-		n, err = procStatFile.Read(buf)
-
-		// close the file
-		_ = procStatFile.Close()
-
-		// check for errors
-		if err != nil {
 			return nil, fmt.Errorf("error reading %s: %w", statFilePath, err)
 		}
 
-		if processStats[pid], err = linux.NewProcessStats(string(buf[0:n])); err != nil {
+		if processStats[pid], err = linux.NewProcessStats(string(data)); err != nil {
 			return nil, err
 		}
 	}
@@ -172,23 +159,20 @@ func getProcessStats(runningProcesses []string) (map[string]linux.ProcessStats, 
 
 // getTotalJiffies returns a sum of all jiffies from /proc/stat
 // We could use C.sysconf(C._SC_CLK_TCK), but that would require CGO and that's not helping with portability.
-func getTotalJiffies() (uint64, error) {
+func getTotalJiffies(ctx context.Context) (uint64, error) {
 	filePath := filepath.Join(linux.ProcFS, "stat")
 
-	file, err := os.Open(filePath)
+	buf, err := files.Read(ctx, files.KernelVirtualFSReadTimeout, 512, filePath)
 	if err != nil {
 		return 0, fmt.Errorf("error reading %s: %w", filePath, err)
 	}
 
-	defer func() { _ = file.Close() }()
-
-	// we don't need to read the whole file, we only care about the first line
-	buf := make([]byte, 512)
-	if _, err = file.Read(buf); err != nil {
-		return 0, fmt.Errorf("error reading contents of %s: %w", filePath, err)
+	// since we are reading limited number of bytes, we need to check that we have newline
+	newline := bytes.IndexByte(buf, '\n')
+	if newline == -1 {
+		newline = len(buf)
 	}
-
-	firstLine := string(buf[0:bytes.Index(buf, []byte("\n"))])
+	firstLine := string(buf[:newline])
 	fields := strings.Fields(firstLine)
 
 	var total, value uint64

--- a/app/inventory/processes_linux_test.go
+++ b/app/inventory/processes_linux_test.go
@@ -19,10 +19,11 @@ import (
 	"testing"
 
 	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 func TestCollectProcessesInventory(t *testing.T) {
-	processes, err := CollectProcessesInventory()
+	processes, err := CollectProcessesInventory(t.Context())
 	if err != nil {
 		t.Fatalf("error collecting processes: %v", err)
 	}
@@ -36,4 +37,7 @@ func TestCollectProcessesInventory(t *testing.T) {
 		assert.NotEmpty(t, process.User)
 		assert.NotEmpty(t, process.Command)
 	}
+
+	// make sure that the goroutine count is back to its original value before collection
+	assert.Equal(t, files.GetGoroutineCount(), int64(0))
 }

--- a/app/inventory/system_linux.go
+++ b/app/inventory/system_linux.go
@@ -19,6 +19,7 @@
 package inventory
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -34,6 +35,7 @@ import (
 	"go.qbee.io/agent/app/log"
 	"go.qbee.io/agent/app/utils"
 	"go.qbee.io/agent/app/utils/cache"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 const (
@@ -42,7 +44,7 @@ const (
 )
 
 // CollectSystemInventory returns populated System inventory based on current system status.
-func CollectSystemInventory(tpmEnabled bool) (*System, error) {
+func CollectSystemInventory(ctx context.Context, tpmEnabled bool) (*System, error) {
 
 	if cachedItem, ok := cache.Get(systemInventoryCacheKey); ok {
 		return cachedItem.(*System), nil
@@ -60,7 +62,7 @@ func CollectSystemInventory(tpmEnabled bool) (*System, error) {
 		return nil, err
 	}
 
-	if err := systemInfo.parseCPUInfo(); err != nil {
+	if err := systemInfo.parseCPUInfo(ctx); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +74,7 @@ func CollectSystemInventory(tpmEnabled bool) (*System, error) {
 		return nil, err
 	}
 
-	if err := systemInfo.gatherNetworkInfo(); err != nil {
+	if err := systemInfo.gatherNetworkInfo(ctx); err != nil {
 		return nil, err
 	}
 
@@ -93,12 +95,12 @@ func CollectSystemInventory(tpmEnabled bool) (*System, error) {
 }
 
 // getDefaultNetworkInterface returns a default network interface name.
-func (systemInfo *SystemInfo) getDefaultNetworkInterface() (string, error) {
+func (systemInfo *SystemInfo) getDefaultNetworkInterface(ctx context.Context) (string, error) {
 	routeFilePath := filepath.Join(linux.ProcFS, "net", "route")
 
 	defaultInterface := ""
 
-	err := utils.ForLinesInFile(routeFilePath, func(line string) error {
+	err := files.ForLinesInFile(ctx, files.KernelVirtualFSReadTimeout, routeFilePath, func(line string) error {
 		fields := strings.Fields(line)
 		if fields[1] == "Destination" {
 			return nil
@@ -122,8 +124,8 @@ func (systemInfo *SystemInfo) getDefaultNetworkInterface() (string, error) {
 }
 
 // gatherNetworkInfo gathers system's networking configuration.
-func (systemInfo *SystemInfo) gatherNetworkInfo() error {
-	defaultNetworkInterface, err := systemInfo.getDefaultNetworkInterface()
+func (systemInfo *SystemInfo) gatherNetworkInfo(ctx context.Context) error {
+	defaultNetworkInterface, err := systemInfo.getDefaultNetworkInterface(ctx)
 	if err != nil {
 		return err
 	}
@@ -234,12 +236,12 @@ func (systemInfo *SystemInfo) parseOSRelease() error {
 }
 
 // parseCPUInfo parses /proc/cpuinfo for extra details re. CPU.
-func (systemInfo *SystemInfo) parseCPUInfo() error {
+func (systemInfo *SystemInfo) parseCPUInfo(ctx context.Context) error {
 	filePath := filepath.Join(linux.ProcFS, "cpuinfo")
 
 	const expectedLineSubstrings = 2
 
-	return utils.ForLinesInFile(filePath, func(line string) error {
+	return files.ForLinesInFile(ctx, files.KernelVirtualFSReadTimeout, filePath, func(line string) error {
 		line = strings.TrimSpace(line)
 
 		substrings := strings.SplitN(line, ":", expectedLineSubstrings)

--- a/app/inventory/system_linux_test.go
+++ b/app/inventory/system_linux_test.go
@@ -23,11 +23,12 @@ import (
 
 	"go.qbee.io/agent/app/inventory"
 	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 func TestCollectSystemInventory(t *testing.T) {
 
-	systemInfo, err := inventory.CollectSystemInventory(true)
+	systemInfo, err := inventory.CollectSystemInventory(t.Context(), true)
 	if err != nil {
 		t.Fatalf("error collecting system info: %v", err)
 	}
@@ -40,4 +41,7 @@ func TestCollectSystemInventory(t *testing.T) {
 	assert.NotEmpty(t, systemInfo.System.Host)
 	assert.NotEmpty(t, systemInfo.System.Architecture)
 	assert.NotEmpty(t, systemInfo.System.OSVersion)
+
+	// make sure that the goroutine count is back to its original value before collection
+	assert.Equal(t, files.GetGoroutineCount(), int64(0))
 }

--- a/app/metrics/cpu.go
+++ b/app/metrics/cpu.go
@@ -18,14 +18,15 @@ package metrics
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // CPUValues contains CPU metrics.
@@ -47,25 +48,22 @@ type CPUValues struct {
 }
 
 // CollectCPU returns CPU metrics.
-func CollectCPU() (*CPUValues, error) {
+func CollectCPU(ctx context.Context) (*CPUValues, error) {
 	filePath := filepath.Join(linux.ProcFS, "stat")
 
-	file, err := os.Open(filePath)
+	buf, err := files.Read(ctx, files.KernelVirtualFSReadTimeout, 512, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", filePath, err)
 	}
 
-	defer func() { _ = file.Close() }()
-
-	// we don't need to read the whole file, we only care about the first line
-	buf := make([]byte, 512)
-	if _, err = file.Read(buf); err != nil {
-		return nil, fmt.Errorf("error reading contents of %s: %w", filePath, err)
+	// since we are reading limited number of bytes, we need to check that we have newline
+	newline := bytes.IndexByte(buf, '\n')
+	if newline == -1 {
+		newline = len(buf)
 	}
+	firstLine := string(buf[:newline])
 
-	firstLine := string(buf[0:bytes.Index(buf, []byte("\n"))])
 	lineFields := strings.Fields(firstLine)
-
 	fields := []string{"user", "nice", "system", "idle", "iowait", "irq"}
 	fieldValues := make(map[string]uint64)
 

--- a/app/metrics/cpu_test.go
+++ b/app/metrics/cpu_test.go
@@ -22,14 +22,14 @@ import (
 )
 
 func TestCollectCPU(t *testing.T) {
-	v, err := CollectCPU()
+	v, err := CollectCPU(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error = %v", err)
 	}
 
 	time.Sleep(1 * time.Second)
 
-	v2, err := CollectCPU()
+	v2, err := CollectCPU(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error = %v", err)
 	}

--- a/app/metrics/filesystem.go
+++ b/app/metrics/filesystem.go
@@ -17,13 +17,14 @@
 package metrics
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
 
 	"go.qbee.io/agent/app/inventory/linux"
-	"go.qbee.io/agent/app/utils"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // FilesystemValues represents filesystem metric values.
@@ -42,8 +43,8 @@ type FilesystemValues struct {
 const fsBlockSize = 1024
 
 // CollectFilesystem returns filesystem metric for each filesystem mounted in read-write mode.
-func CollectFilesystem() ([]Metric, error) {
-	mounts, err := getFilesystemMounts()
+func CollectFilesystem(ctx context.Context) ([]Metric, error) {
+	mounts, err := getFilesystemMounts(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +84,8 @@ func CollectFilesystem() ([]Metric, error) {
 }
 
 // getFilesystemMounts returns a list of block-device mount points.
-func getFilesystemMounts() ([]string, error) {
-	supportedFilesystems, err := getSupportedFilesystems()
+func getFilesystemMounts(ctx context.Context) ([]string, error) {
+	supportedFilesystems, err := getSupportedFilesystems(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +94,7 @@ func getFilesystemMounts() ([]string, error) {
 
 	mounts := make([]string, 0)
 
-	err = utils.ForLinesInFile(path, func(line string) error {
+	err = files.ForLinesInFile(ctx, files.KernelVirtualFSReadTimeout, path, func(line string) error {
 		fields := strings.Fields(line)
 
 		if fields[3] != "rw" && !strings.HasPrefix(fields[3], "rw,") {
@@ -114,12 +115,12 @@ func getFilesystemMounts() ([]string, error) {
 }
 
 // getSupportedFilesystems returns a map of supported block-device filesystems.
-func getSupportedFilesystems() (map[string]bool, error) {
+func getSupportedFilesystems(ctx context.Context) (map[string]bool, error) {
 	path := filepath.Join(linux.ProcFS, "filesystems")
 
 	filesystems := make(map[string]bool)
 
-	err := utils.ForLinesInFile(path, func(line string) error {
+	err := files.ForLinesInFile(ctx, files.KernelVirtualFSReadTimeout, path, func(line string) error {
 		if strings.HasPrefix(line, "nodev") {
 			return nil
 		}

--- a/app/metrics/filesystem_test.go
+++ b/app/metrics/filesystem_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestCollectFilesystem(t *testing.T) {
-	gotMetrics, err := CollectFilesystem()
+	gotMetrics, err := CollectFilesystem(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error = %v", err)
 	}

--- a/app/metrics/loadavg.go
+++ b/app/metrics/loadavg.go
@@ -17,14 +17,15 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"go.qbee.io/agent/app/inventory/linux"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // LoadAverageValues contains load average metrics.
@@ -48,10 +49,10 @@ type LoadAverageValues struct {
 }
 
 // CollectLoadAverage metrics.
-func CollectLoadAverage() ([]Metric, error) {
+func CollectLoadAverage(ctx context.Context) ([]Metric, error) {
 	path := filepath.Join(linux.ProcFS, "loadavg")
 
-	data, err := os.ReadFile(path)
+	data, err := files.ReadAll(ctx, files.KernelVirtualFSReadTimeout, path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", path, err)
 	}

--- a/app/metrics/loadavg_test.go
+++ b/app/metrics/loadavg_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCollectLoadAverage(t *testing.T) {
-	gotMetrics, err := CollectLoadAverage()
+	gotMetrics, err := CollectLoadAverage(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/app/metrics/memory.go
+++ b/app/metrics/memory.go
@@ -17,13 +17,14 @@
 package metrics
 
 import (
+	"context"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"go.qbee.io/agent/app/inventory/linux"
-	"go.qbee.io/agent/app/utils"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // MemoryValues contains memory metrics.
@@ -47,12 +48,12 @@ type MemoryValues struct {
 }
 
 // CollectMemory metrics.
-func CollectMemory() ([]Metric, error) {
+func CollectMemory(ctx context.Context) ([]Metric, error) {
 	path := filepath.Join(linux.ProcFS, "meminfo")
 
 	values := new(MemoryValues)
 
-	err := utils.ForLinesInFile(path, func(line string) error {
+	err := files.ForLinesInFile(ctx, files.KernelVirtualFSReadTimeout, path, func(line string) error {
 		fields := strings.Fields(line)
 		if len(fields) != 3 {
 			return nil

--- a/app/metrics/memory_test.go
+++ b/app/metrics/memory_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCollectMemory(t *testing.T) {
-	gotMetrics, err := CollectMemory()
+	gotMetrics, err := CollectMemory(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -39,6 +39,4 @@ func TestCollectMemory(t *testing.T) {
 	if time.Since(time.Unix(metric.Timestamp, 0)) > time.Second {
 		t.Fatalf("invalid timestamp, got: %v", metric.Timestamp)
 	}
-
-	//fmt.Printf("%#v\n", metric.Values.MemoryValues)
 }

--- a/app/metrics/network.go
+++ b/app/metrics/network.go
@@ -17,13 +17,14 @@
 package metrics
 
 import (
+	"context"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"go.qbee.io/agent/app/inventory/linux"
-	"go.qbee.io/agent/app/utils"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // NetworkValues contains network metrics for an interface.
@@ -49,12 +50,12 @@ type NetworkValues struct {
 // CollectNetwork metrics.
 // Note: collected are total values. The agent must report delta,
 // so we need to keep state from the last report and subtract it before delivery.
-func CollectNetwork() ([]Metric, error) {
+func CollectNetwork(ctx context.Context) ([]Metric, error) {
 	path := filepath.Join(linux.ProcFS, "net", "dev")
 
 	metrics := make([]Metric, 0)
 
-	err := utils.ForLinesInFile(path, func(line string) error {
+	err := files.ForLinesInFile(ctx, files.KernelVirtualFSReadTimeout, path, func(line string) error {
 		fields := strings.Fields(line)
 
 		if !strings.HasSuffix(fields[0], ":") {

--- a/app/metrics/network_test.go
+++ b/app/metrics/network_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCollectNetwork(t *testing.T) {
-	v1, err := CollectNetwork()
+	v1, err := CollectNetwork(t.Context())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestCollectNetwork(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	v2, err := CollectNetwork()
+	v2, err := CollectNetwork(t.Context())
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/app/metrics/service.go
+++ b/app/metrics/service.go
@@ -17,6 +17,7 @@
 package metrics
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -43,7 +44,7 @@ func New(apiClient *api.Client) *Service {
 
 type metricsCollector struct {
 	name string
-	fn   func() ([]Metric, error)
+	fn   func(ctx context.Context) ([]Metric, error)
 }
 
 var metricsCollectors = []metricsCollector{
@@ -71,7 +72,7 @@ var metricsCacheTTL = 60 * time.Second
 
 // Collect system metrics.
 // If any errors are encountered, they'll be logged, but won't interrupt the process.
-func (s *Service) Collect() []Metric {
+func (s *Service) Collect(ctx context.Context) []Metric {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -83,7 +84,7 @@ func (s *Service) Collect() []Metric {
 
 	// collect metrics which don't depend on state
 	for _, collector := range metricsCollectors {
-		if metrics, err := collector.fn(); err != nil {
+		if metrics, err := collector.fn(ctx); err != nil {
 			log.Errorf("%s metrics error: %v", collector.name, err)
 		} else {
 			allMetrics = append(allMetrics, metrics...)
@@ -91,13 +92,13 @@ func (s *Service) Collect() []Metric {
 	}
 
 	// collect metrics which require previous state to produce delta-metrics
-	if cpuMetric, err := s.doCollectCPU(); err != nil {
+	if cpuMetric, err := s.doCollectCPU(ctx); err != nil {
 		log.Errorf("cpu metrics error: %v", err)
 	} else if cpuMetric != nil {
 		allMetrics = append(allMetrics, *cpuMetric)
 	}
 
-	if networkMetrics, err := s.doCollectNetwork(); err != nil {
+	if networkMetrics, err := s.doCollectNetwork(ctx); err != nil {
 		log.Errorf("network metrics error: %v", err)
 	} else if networkMetrics != nil {
 		allMetrics = append(allMetrics, networkMetrics...)
@@ -108,9 +109,9 @@ func (s *Service) Collect() []Metric {
 	return allMetrics
 }
 
-func (s *Service) doCollectCPU() (*Metric, error) {
+func (s *Service) doCollectCPU(ctx context.Context) (*Metric, error) {
 
-	cpuValues, err := CollectCPU()
+	cpuValues, err := CollectCPU(ctx)
 
 	if err != nil {
 		return nil, err
@@ -139,9 +140,9 @@ func (s *Service) doCollectCPU() (*Metric, error) {
 	}, nil
 }
 
-func (s *Service) doCollectNetwork() ([]Metric, error) {
+func (s *Service) doCollectNetwork(ctx context.Context) ([]Metric, error) {
 
-	networkValues, err := CollectNetwork()
+	networkValues, err := CollectNetwork(ctx)
 
 	if err != nil {
 		return nil, err

--- a/app/metrics/service_test.go
+++ b/app/metrics/service_test.go
@@ -23,14 +23,18 @@ import (
 	"time"
 
 	"go.qbee.io/agent/app/api"
+	"go.qbee.io/agent/app/utils/assert"
+	"go.qbee.io/agent/app/utils/cache"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 func TestCollectServiceCollectAll(t *testing.T) {
 	apiClient, _ := api.NewMockedClient()
 
+	cache.Clear()
 	srv := New(apiClient)
 
-	gotMetrics := srv.Collect()
+	gotMetrics := srv.Collect(t.Context())
 
 	if len(gotMetrics) == 0 {
 		t.Fatalf("expected at least one metric, got 0")
@@ -46,7 +50,7 @@ func TestCollectServiceCollectAll(t *testing.T) {
 	// Sleep to get deltas
 	time.Sleep(1 * time.Second)
 
-	gotMetrics = srv.Collect()
+	gotMetrics = srv.Collect(t.Context())
 	metricBytes, err = json.MarshalIndent(gotMetrics, "", "  ")
 
 	if err != nil {
@@ -54,4 +58,12 @@ func TestCollectServiceCollectAll(t *testing.T) {
 	}
 
 	fmt.Printf("got metrics: %s", string(metricBytes))
+}
+
+func Test_GoroutineCountAfterAllMetrics(t *testing.T) {
+	cache.Clear()
+	apiClient, _ := api.NewMockedClient()
+	srv := New(apiClient)
+	srv.Collect(t.Context())
+	assert.Equal(t, files.GetGoroutineCount(), int64(0))
 }

--- a/app/metrics/service_test.go
+++ b/app/metrics/service_test.go
@@ -65,5 +65,7 @@ func Test_GoroutineCountAfterAllMetrics(t *testing.T) {
 	apiClient, _ := api.NewMockedClient()
 	srv := New(apiClient)
 	srv.Collect(t.Context())
-	assert.Equal(t, files.GetGoroutineCount(), int64(0))
+	assert.EventuallyTrue(t, func() bool {
+		return files.GetGoroutineCount() == int64(0)
+	}, time.Second)
 }

--- a/app/metrics/temperature.go
+++ b/app/metrics/temperature.go
@@ -17,8 +17,8 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -26,6 +26,7 @@ import (
 
 	"go.qbee.io/agent/app/inventory/linux"
 	"go.qbee.io/agent/app/log"
+	"go.qbee.io/agent/app/utils/files"
 )
 
 // TemperatureValues represents temperature metrics
@@ -46,18 +47,18 @@ type cpuTemperatures struct {
 const hostTemperatureScale = 1000.0
 
 // CollectTemperature collects temperature metrics from from /sys/class/[hwmon|thermal]
-func CollectTemperature() ([]Metric, error) {
+func CollectTemperature(ctx context.Context) ([]Metric, error) {
 
 	cpuTemps := new(cpuTemperatures)
 	var errString string
 
 	// Attempt to collect temperature metrics from hwmon
-	if err := cpuTemps.hwMonTemperatureMetrics(); err != nil {
+	if err := cpuTemps.hwMonTemperatureMetrics(ctx); err != nil {
 		errString += err.Error()
 	}
 
 	// Attempt to collect temperature metrics from thermal zone
-	if err := cpuTemps.thermalZoneTemperatureMetrics(); err != nil {
+	if err := cpuTemps.thermalZoneTemperatureMetrics(ctx); err != nil {
 		errString += err.Error()
 	}
 
@@ -82,18 +83,18 @@ func CollectTemperature() ([]Metric, error) {
 }
 
 // hwMonTemperatureMetrics collects temperature metrics from /sys/class/hwmon/hwmon*/temp*_input
-func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
+func (c *cpuTemperatures) hwMonTemperatureMetrics(ctx context.Context) error {
 
-	files, err := getHwMonFiles()
+	hwMonFiles, err := getHwMonFiles(ctx)
 	if err != nil {
 		return err
 	}
 
-	if len(files) == 0 {
+	if len(hwMonFiles) == 0 {
 		return fmt.Errorf("no hwmon temperature metrics found")
 	}
 
-	for _, file := range files {
+	for _, file := range hwMonFiles {
 		var raw []byte
 		var temperature float64
 		// Get the base directory location
@@ -105,14 +106,14 @@ func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
 		// Get the label of the temperature you are reading
 		label := ""
 
-		if raw, _ = os.ReadFile(basepath + "_label"); len(raw) != 0 {
+		if raw, _ = files.ReadAll(ctx, files.KernelVirtualFSReadTimeout, basepath+"_label"); len(raw) != 0 {
 			// Format the label from "Core 0" to "core_0"
 			label = strings.Join(strings.Split(strings.TrimSpace(strings.ToLower(string(raw))), " "), "_")
 		}
 
 		// Some boards have a cpu_thermal zone
 		if strings.HasPrefix(label, "cpu_thermal") {
-			temperature, err = parseTemperatureFile(file)
+			temperature, err = parseTemperatureFile(ctx, file)
 			if err != nil {
 				continue
 			}
@@ -121,7 +122,7 @@ func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
 
 		// Capture all core temperatures
 		if strings.HasPrefix(label, "core") {
-			temperature, err = parseTemperatureFile(file)
+			temperature, err = parseTemperatureFile(ctx, file)
 			if err != nil {
 				continue
 			}
@@ -130,7 +131,7 @@ func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
 
 		// Capture all socket temperatures
 		if strings.Contains(label, "package") || strings.Contains(label, "physical") || label == "tccd1" {
-			temperature, err = parseTemperatureFile(file)
+			temperature, err = parseTemperatureFile(ctx, file)
 			if err != nil {
 				continue
 			}
@@ -151,20 +152,20 @@ func (c *cpuTemperatures) hwMonTemperatureMetrics() error {
 }
 
 // thermalZoneTemperatureMetrics collects temperature metrics from /sys/class/thermal/thermal_zone*/temp
-func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
+func (c *cpuTemperatures) thermalZoneTemperatureMetrics(ctx context.Context) error {
 
-	files, err := getThermalZoneFiles()
+	thermalZoneFiles, err := getThermalZoneFiles(ctx)
 	if err != nil {
 		return err
 	}
 
-	if len(files) == 0 {
+	if len(thermalZoneFiles) == 0 {
 		return fmt.Errorf("no thermal zone metrics found")
 	}
 
-	for _, file := range files {
+	for _, file := range thermalZoneFiles {
 		// Get the name of the temperature you are reading
-		rawName, err := os.ReadFile(filepath.Join(file, "type"))
+		rawName, err := files.ReadAll(ctx, files.KernelVirtualFSReadTimeout, filepath.Join(file, "type"))
 		if err != nil {
 			continue
 		}
@@ -173,7 +174,7 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 
 		// Some boards have acpi_thermal zones
 		if strings.HasPrefix(name, "acpi") {
-			acpiTemp, err := parseTemperatureFile(filepath.Join(file, "temp"))
+			acpiTemp, err := parseTemperatureFile(ctx, filepath.Join(file, "temp"))
 			if err != nil {
 				continue
 			}
@@ -182,7 +183,7 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 
 		// Some boards have a pch_thermal zone
 		if strings.HasPrefix(name, "pch") {
-			chipsetTemp, err := parseTemperatureFile(filepath.Join(file, "temp"))
+			chipsetTemp, err := parseTemperatureFile(ctx, filepath.Join(file, "temp"))
 			if err != nil {
 				continue
 			}
@@ -190,7 +191,7 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 		}
 		// ARM based boards have cpu-thermal zones
 		if strings.HasPrefix(name, "cpu-thermal") {
-			cpuTemp, err := parseTemperatureFile(filepath.Join(file, "temp"))
+			cpuTemp, err := parseTemperatureFile(ctx, filepath.Join(file, "temp"))
 			if err != nil {
 				continue
 			}
@@ -201,8 +202,8 @@ func (c *cpuTemperatures) thermalZoneTemperatureMetrics() error {
 }
 
 // parseTemperatureFile reads a temperature file and returns the temperature in degrees Celsius
-func parseTemperatureFile(file string) (float64, error) {
-	raw, err := os.ReadFile(file)
+func parseTemperatureFile(ctx context.Context, tempFile string) (float64, error) {
+	raw, err := files.ReadAll(ctx, files.KernelVirtualFSReadTimeout, tempFile)
 	if err != nil {
 		return 0, err
 	}
@@ -216,9 +217,9 @@ func parseTemperatureFile(file string) (float64, error) {
 }
 
 // getThermalZoneFiles returns a list of temperature files in /sys/class/thermal/thermal_zone*/temp
-func getThermalZoneFiles() ([]string, error) {
+func getThermalZoneFiles(ctx context.Context) ([]string, error) {
 	globPath := filepath.Join(linux.SysFS, "class", "thermal", "thermal_zone*")
-	files, err := filepath.Glob(globPath)
+	files, err := files.Glob(ctx, files.KernelVirtualFSReadTimeout, globPath)
 	if err != nil {
 		return nil, err
 	}
@@ -227,21 +228,21 @@ func getThermalZoneFiles() ([]string, error) {
 }
 
 // getHwMonFiles returns a list of temperature files in /sys/class/hwmon/hwmon*/temp*_input
-func getHwMonFiles() ([]string, error) {
+func getHwMonFiles(ctx context.Context) ([]string, error) {
 	globPath := filepath.Join(linux.SysFS, "class", "hwmon", "hwmon*", "temp*_input")
-	files, err := filepath.Glob(globPath)
+	hvMonFiles, err := files.Glob(ctx, files.KernelVirtualFSReadTimeout, globPath)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(files) == 0 {
+	if len(hvMonFiles) == 0 {
 		// CentOS has an intermediate /device directory:
 		// https://github.com/giampaolo/psutil/issues/971
 		globPath = filepath.Join(linux.SysFS, "class", "hwmon", "hwmon*", "device", "temp*_input")
-		if files, err = filepath.Glob(globPath); err != nil {
+		if hvMonFiles, err = files.Glob(ctx, files.KernelVirtualFSReadTimeout, globPath); err != nil {
 			return nil, err
 		}
 	}
 
-	return files, nil
+	return hvMonFiles, nil
 }

--- a/app/metrics/temperature_test.go
+++ b/app/metrics/temperature_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestCollectTemperature(t *testing.T) {
 
-	metrics, _ := CollectTemperature()
+	metrics, _ := CollectTemperature(t.Context())
 
 	if len(metrics) == 0 {
 		t.Skip("no temperature metrics available")

--- a/app/utils/cache/cache.go
+++ b/app/utils/cache/cache.go
@@ -64,3 +64,11 @@ func Delete(key string) {
 
 	delete(items, key)
 }
+
+// Clear clears the cache
+func Clear() {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	items = make(map[string]item)
+}

--- a/app/utils/files/files.go
+++ b/app/utils/files/files.go
@@ -1,0 +1,189 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"time"
+)
+
+// goroutineCount tracks the number of active goroutines
+var goroutineCount int64
+
+// maxGoroutines defines the maximum number of concurrent goroutines allowed for file IO operations.
+const maxGoroutines = 500
+
+// GoroutinesExhausted reports whether the context file IO goroutine budget is exhausted.
+func GoroutinesExhausted() bool {
+	return atomic.LoadInt64(&goroutineCount) >= maxGoroutines
+}
+
+// SetGoroutineCountForTesting sets the goroutine count for testing purposes.
+// This is only intended for use in tests.
+func SetGoroutineCountForTesting(count int64) {
+	atomic.StoreInt64(&goroutineCount, count)
+}
+
+// GetGoroutineCount returns the current goroutine count for testing purposes.
+// This is only intended for use in tests.
+func GetGoroutineCount() int64 {
+	return atomic.LoadInt64(&goroutineCount)
+}
+
+// reserveGoroutineSlot attempts to reserve a slot for a new goroutine. It returns true if successful, false if the
+// maximum number of goroutines has been reached. This method is safe for Time-of-Check to Time-of-Use (TOCTOU) race
+// conditions. For loop ensures retries until the slot is successfully reserved or the maximum number of goroutines is reached.
+func reserveGoroutineSlot() bool {
+	for {
+		current := atomic.LoadInt64(&goroutineCount)
+		if current >= maxGoroutines {
+			return false
+		}
+
+		if atomic.CompareAndSwapInt64(&goroutineCount, current, current+1) {
+			return true
+		}
+	}
+}
+
+// releaseGoroutineSlot releases a previously reserved goroutine slot, decrementing the goroutine count unconditionally.
+func releaseGoroutineSlot() {
+	atomic.AddInt64(&goroutineCount, -1)
+}
+
+// KernelVirtualFSReadTimeout limits reads/opens on virtual kernel filesystems.
+const KernelVirtualFSReadTimeout = 2 * time.Second
+
+// Read reads the contents of a file with context cancellation support.
+func Read(ctx context.Context, timeout time.Duration, maxBytes int64, filePath string) ([]byte, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var result []byte
+	outerErr := fileOperationWithContext(ctxWithTimeout, func() error {
+		file, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = file.Close() }()
+
+		// If maxBytes is less than or equal to 0, read the entire file without limiting the number of bytes.
+		if maxBytes <= 0 {
+			result, err = io.ReadAll(file)
+			return err
+		}
+
+		result, err = io.ReadAll(io.LimitReader(file, maxBytes))
+		return err
+	})
+
+	if outerErr != nil {
+		return nil, outerErr
+	}
+	return result, nil
+}
+
+// ReadAll reads the entire contents of a file with context cancellation support, up to a maximum number of bytes.
+func ReadAll(ctx context.Context, timeout time.Duration, filePath string) ([]byte, error) {
+	return Read(ctx, timeout, -1, filePath)
+}
+
+// Glob performs a filepath.Glob operation with context cancellation support.
+func Glob(ctx context.Context, timeout time.Duration, pattern string) ([]string, error) {
+
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var result []string
+
+	outerErr := fileOperationWithContext(ctxWithTimeout, func() error {
+		var err error
+		result, err = filepath.Glob(pattern)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if outerErr != nil {
+		return nil, outerErr
+	}
+	return result, nil
+}
+
+// ListDirectory lists files and directories in a directory with context cancellation support.
+func ListDirectory(ctx context.Context, timeOut time.Duration, dirPath string) ([]string, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeOut)
+	defer cancel()
+
+	var result []string
+
+	outerErr := fileOperationWithContext(ctxWithTimeout, func() error {
+		dir, err := os.Open(dirPath)
+		if err != nil {
+			return err
+		}
+
+		defer func() { _ = dir.Close() }()
+
+		result, err = dir.Readdirnames(-1)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if outerErr != nil {
+		return nil, outerErr
+	}
+	return result, nil
+}
+
+// Stat performs an os.Stat operation with context cancellation support.
+func Stat(ctx context.Context, timeOut time.Duration, path string) (os.FileInfo, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeOut)
+	defer cancel()
+	var result os.FileInfo
+
+	outerErr := fileOperationWithContext(ctxWithTimeout, func() error {
+		var err error
+		result, err = os.Stat(path)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if outerErr != nil {
+		return nil, outerErr
+	}
+	return result, nil
+}
+
+// fileOperationWithContext executes a file operation in a separate goroutine while respecting context cancellation.
+// It ensures that the operation does not block the main goroutine and releases the goroutine slot after completion.
+func fileOperationWithContext(ctx context.Context, operation func() error) error {
+	if !reserveGoroutineSlot() {
+		return fmt.Errorf("goroutine budget exhausted")
+	}
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer func() {
+			releaseGoroutineSlot()
+		}()
+
+		errCh <- operation()
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	}
+}

--- a/app/utils/files/files.go
+++ b/app/utils/files/files.go
@@ -173,10 +173,7 @@ func fileOperationWithContext(ctx context.Context, operation func() error) error
 	errCh := make(chan error, 1)
 
 	go func() {
-		defer func() {
-			releaseGoroutineSlot()
-		}()
-
+		defer releaseGoroutineSlot()
 		errCh <- operation()
 	}()
 

--- a/app/utils/files/files.go
+++ b/app/utils/files/files.go
@@ -86,7 +86,7 @@ func Read(ctx context.Context, timeout time.Duration, maxBytes int64, filePath s
 	return result, nil
 }
 
-// ReadAll reads the entire contents of a file with context cancellation support, up to a maximum number of bytes.
+// ReadAll reads the entire contents of a file with context cancellation support.
 func ReadAll(ctx context.Context, timeout time.Duration, filePath string) ([]byte, error) {
 	return Read(ctx, timeout, -1, filePath)
 }

--- a/app/utils/files/files_test.go
+++ b/app/utils/files/files_test.go
@@ -1,0 +1,133 @@
+package files
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"go.qbee.io/agent/app/utils/assert"
+)
+
+func TestExhaustGoRoutines(t *testing.T) {
+	// Reset the goroutine count before the test
+	atomic.StoreInt64(&goroutineCount, 0)
+
+	// Reserve the maximum number of goroutines
+	for i := range maxGoroutines {
+		if !reserveGoroutineSlot() {
+			t.Fatalf("Failed to reserve goroutine slot at iteration %d", i)
+		}
+	}
+
+	// Check that GoroutinesExhausted returns true when all slots are reserved
+	assert.True(t, GoroutinesExhausted())
+
+	// Try to reserve one more slot, which should fail
+	assert.False(t, reserveGoroutineSlot())
+}
+
+func TestOpenFileWithContextClosesLateFile(t *testing.T) {
+	fifoPath := t.TempDir() + "/test_fifo"
+	atomic.StoreInt64(&goroutineCount, 0)
+	assert.NoError(t, syscall.Mkfifo(fifoPath, 0666))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := ReadAll(ctx, KernelVirtualFSReadTimeout, fifoPath)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+
+	writer, err := os.OpenFile(fifoPath, os.O_WRONLY, 0)
+	assert.NoError(t, err)
+	assert.NoError(t, writer.Close())
+
+	assert.EventuallyTrue(t, func() bool {
+		return atomic.LoadInt64(&goroutineCount) == 0
+	}, time.Second)
+}
+
+func TestExhaustGoRoutinesPipeReads(t *testing.T) {
+
+	fifoPath := t.TempDir() + "/test_fifo"
+
+	// Reset the goroutine count before the test
+	atomic.StoreInt64(&goroutineCount, 0)
+	// Create a named pipe (FIFO)
+	assert.NoError(t, syscall.Mkfifo(fifoPath, 0666))
+	// ReadFileContext for max go routines + 1 and wait for them to timeout,
+	// then check that the goroutine count is still at maxGoroutines.
+	var wg sync.WaitGroup
+	for range maxGoroutines + 1 {
+		wg.Go(func() {
+			readCtx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+			defer cancel()
+			_, _ = ReadAll(readCtx, KernelVirtualFSReadTimeout, fifoPath)
+		})
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, atomic.LoadInt64(&goroutineCount), int64(maxGoroutines))
+
+	// try to read once more, which should fail to reserve a slot
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err := ReadAll(ctx, KernelVirtualFSReadTimeout, fifoPath)
+	assert.NotEmpty(t, err)
+	assert.Equal(t, atomic.LoadInt64(&goroutineCount), int64(maxGoroutines))
+
+	// Cleanup: unblock the background FIFO opens so goroutine slots are released.
+	writer, werr := os.OpenFile(fifoPath, os.O_WRONLY, 0)
+	assert.NoError(t, werr)
+	assert.NoError(t, writer.Close())
+	assert.EventuallyTrue(t, func() bool {
+		return atomic.LoadInt64(&goroutineCount) == 0
+	}, time.Second)
+}
+
+// Test timeouts for path-based file operations (ReadFile and ListDirectory) using named pipes (FIFOs)
+func Test_FileTimeouts(t *testing.T) {
+
+	tests := []struct {
+		name string
+		fn   func(ctx context.Context, path string) error
+	}{
+		{
+			name: "ReadFileTimeout",
+			fn: func(ctx context.Context, path string) error {
+				_, err := ReadAll(ctx, KernelVirtualFSReadTimeout, path)
+				return err
+			}},
+		{
+			name: "ListDirectoryTimeout",
+			fn: func(ctx context.Context, path string) error {
+				_, err := ListDirectory(ctx, KernelVirtualFSReadTimeout, path)
+				return err
+			}},
+	}
+
+	fifoPath := t.TempDir() + "/test_fifo"
+
+	assert.NoError(t, syscall.Mkfifo(fifoPath, 0666))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			atomic.StoreInt64(&goroutineCount, 0)
+
+			ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+			defer cancel()
+
+			err := tt.fn(ctx, fifoPath)
+			assert.True(t, errors.Is(err, context.DeadlineExceeded))
+
+			// Check that the goroutine count is 1 after the timeout occurred
+			assert.True(t, atomic.LoadInt64(&goroutineCount) == 1)
+		})
+	}
+}

--- a/app/utils/files/files_test.go
+++ b/app/utils/files/files_test.go
@@ -126,8 +126,14 @@ func Test_FileTimeouts(t *testing.T) {
 			err := tt.fn(ctx, fifoPath)
 			assert.True(t, errors.Is(err, context.DeadlineExceeded))
 
-			// Check that the goroutine count is 1 after the timeout occurred
-			assert.True(t, atomic.LoadInt64(&goroutineCount) == 1)
+			// The timed-out operation is still blocked in os.Open; unblock it and wait for cleanup.
+			assert.Equal(t, atomic.LoadInt64(&goroutineCount), int64(1))
+			writer, writerErr := os.OpenFile(fifoPath, os.O_WRONLY, 0)
+			assert.NoError(t, writerErr)
+			assert.NoError(t, writer.Close())
+			assert.EventuallyTrue(t, func() bool {
+				return atomic.LoadInt64(&goroutineCount) == 0
+			}, time.Second)
 		})
 	}
 }

--- a/app/utils/files/parsers.go
+++ b/app/utils/files/parsers.go
@@ -1,0 +1,26 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"go.qbee.io/agent/app/utils"
+)
+
+// ForLinesInFile runs fn for every line in the provided filePath with a context.
+func ForLinesInFile(ctx context.Context, timeOut time.Duration, filePath string, fn func(string) error) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeOut)
+	defer cancel()
+
+	return fileOperationWithContext(ctxWithTimeout, func() error {
+		file, err := os.Open(filePath)
+		if err != nil {
+			return fmt.Errorf("error opening file %s: %w", filePath, err)
+		}
+		defer func() { _ = file.Close() }()
+
+		return utils.ForLines(file, fn)
+	})
+}

--- a/app/utils/parsers.go
+++ b/app/utils/parsers.go
@@ -33,15 +33,14 @@ func ForLines(reader io.Reader, fn func(string) error) error {
 
 	var lineNumber uint64
 	for scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("error reading line: %w", err)
-		}
-
 		lineNumber++
 
 		if err := fn(scanner.Text()); err != nil {
 			return fmt.Errorf("error processing line %d: %w", lineNumber, err)
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading line: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This pull request refactors several inventory and metrics collection functions to require a `context.Context` parameter, improving consistency and enabling better control over timeouts and cancellations. It also introduces a mechanism to detect and report when the agent's goroutine budget is exhausted, ensuring the agent does not proceed when system resources are low and that this state is reported to the server. Additional updates include improved error handling, new tests for the reporting mechanism, and minor code cleanup.

**Agent resource exhaustion reporting:**

* Added `ReportExhaustedGoroutineBudget` to the `Service` struct, which checks if the goroutine budget is exhausted, reports this event, and ensures the report is sent or buffered for later delivery. This is now called at the start of each agent run to prevent further actions if resources are low. [[1]](diffhunk://#diff-c63f39254f9b47933133572971041023b6e3a071fdfd1a59b605c37503df1134R332-R364) [[2]](diffhunk://#diff-6fd0853988157e347f8787a4ecc15581c31ef4c6cc21600ed3678846b81ee28eR176-R184)
* Introduced a new bundle type `bundleAgentInternal` for internal agent events, such as goroutine budget exhaustion.
* Added a test for the new reporting mechanism to ensure proper behavior and buffering of reports.

**Inventory and metrics collection refactor:**

* Updated all inventory collection functions (`CollectSystemInventory`, `CollectPortsInventory`, `CollectProcessesInventory`) and related calls to accept a `context.Context` argument, propagating context for better timeout and cancellation handling. [[1]](diffhunk://#diff-acf73a5f3f07d19ea4ae2c6f9cb68eecac2b5155c9d9886f7a057ab2d67d3242L145-R148) [[2]](diffhunk://#diff-c06dc4e0048e63b642511f2338f2abad190a5dc4b54c4059566ae4681f904767L64-R64) [[3]](diffhunk://#diff-c06dc4e0048e63b642511f2338f2abad190a5dc4b54c4059566ae4681f904767L90-R90) [[4]](diffhunk://#diff-c06dc4e0048e63b642511f2338f2abad190a5dc4b54c4059566ae4681f904767L199-R199) [[5]](diffhunk://#diff-edfcdffd373dc476c10a7428b3739c3e2cce663afd0406877bc2a8e972b850a5L71-R75) [[6]](diffhunk://#diff-b2d3118f3730a16c163d5446dcf2d3437d75d253553057a851a49a8e3df8affdL97-R139) [[7]](diffhunk://#diff-d48f6a77378599b16d16608627e8740b3eeee9260eaef023e2fc994d829f6ef7L57-R57)
* Refactored metrics collection to require a context, updating both production and test code to pass the appropriate context. [[1]](diffhunk://#diff-fe8f4a8975ee160e38bb2753fe91a446dd389dd25c8e12e1f42e5259a855d685L93-R93) [[2]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L77-R77) [[3]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L86-R86) [[4]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L109-R109) [[5]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L127-R127) [[6]](diffhunk://#diff-725efb3728924b1aee90a4d7009a751b5ab6f1b29b549d9c7e7b3ae29f3a2f47L157-R150)

**Linux process and memory info improvements:**

* Refactored low-level Linux utilities (`GetMemInfo`, `GetProcessStatus`, `ListRunningProcesses`, `ListRunningProcessesNames`) to accept a context and use the new `files` utility package for file operations with timeouts, replacing the previous `utils` package. [[1]](diffhunk://#diff-ec89597e34d37581c5338db14f98ea269503bd468f9c5e8e1bd508ca1c31dd22R22-R28) [[2]](diffhunk://#diff-ec89597e34d37581c5338db14f98ea269503bd468f9c5e8e1bd508ca1c31dd22L41-R47) [[3]](diffhunk://#diff-50ac68116724d55357dc21c74040c71362e02436beb63385bbd418e8598dec53R22-R29) [[4]](diffhunk://#diff-50ac68116724d55357dc21c74040c71362e02436beb63385bbd418e8598dec53L39-R44) [[5]](diffhunk://#diff-cd2dd05502ab1e9df9ff593bdc9491f52f466e75e6f20dce167d467321334365R22-R32) [[6]](diffhunk://#diff-cd2dd05502ab1e9df9ff593bdc9491f52f466e75e6f20dce167d467321334365L51-R52)
* Updated process watch bundle to use the new context-aware process listing function.

**Internal utility and import updates:**

* Updated imports and internal utility usage to support the new context-aware file operations. [[1]](diffhunk://#diff-c63f39254f9b47933133572971041023b6e3a071fdfd1a59b605c37503df1134R33) [[2]](diffhunk://#diff-2fe7ac568ac22100a6ccfaa56fcc6bc48642c51d5820c37c5e16a5b09e29ab73R34) [[3]](diffhunk://#diff-ec89597e34d37581c5338db14f98ea269503bd468f9c5e8e1bd508ca1c31dd22R22-R28) [[4]](diffhunk://#diff-50ac68116724d55357dc21c74040c71362e02436beb63385bbd418e8598dec53R22-R29) [[5]](diffhunk://#diff-cd2dd05502ab1e9df9ff593bdc9491f52f466e75e6f20dce167d467321334365R22-R32)

**Test and code cleanup:**

* Removed redundant test assertions and improved test structure for metrics monitor state tests.

These changes collectively improve the agent's robustness, observability, and maintainability by ensuring resource exhaustion is handled gracefully and by standardizing context usage across system operations.