### PR TITLE
DEV-3118: Sanitize OS hostname before use

### DIFF
--- a/app/configuration/bundle_parameters.go
+++ b/app/configuration/bundle_parameters.go
@@ -19,13 +19,12 @@ package configuration
 import (
 	"context"
 	"fmt"
-	"os"
 	"path"
-	"regexp"
 	"strings"
 
 	"go.qbee.io/agent/app/inventory"
 	"go.qbee.io/agent/app/software"
+	"go.qbee.io/agent/app/utils"
 )
 
 // Parameter defines a parameters as key/value pair.
@@ -78,22 +77,9 @@ const (
 	parameterKeyFilePrefix = "file://"
 )
 
-var hostnameRe = regexp.MustCompile("[^a-zA-Z0-9-]")
-
-// sanitizeHostname removes all characters from the hostname that are not letters, numbers, or hyphens.
-// Sanitization rules: https://man7.org/linux/man-pages/man5/hostname.5.html
-func sanitizeHostname(hostname string) string {
-	return hostnameRe.ReplaceAllString(hostname, "")
-}
-
 var systemParameters = map[string]func(ctx context.Context) (string, error){
 	"sys.host": func(ctx context.Context) (string, error) {
-		hostname, err := os.Hostname()
-		if err != nil {
-			return "", err
-		}
-
-		return sanitizeHostname(hostname), nil
+		return utils.Hostname()
 	},
 	"sys.pkg_arch": func(ctx context.Context) (string, error) {
 		if software.DefaultPackageManager == nil {

--- a/app/configuration/bundle_parameters.go
+++ b/app/configuration/bundle_parameters.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
 	"go.qbee.io/agent/app/inventory"
@@ -77,9 +78,22 @@ const (
 	parameterKeyFilePrefix = "file://"
 )
 
+var hostnameRe = regexp.MustCompile("[^a-zA-Z0-9-]")
+
+// sanitizeHostname removes all characters from the hostname that are not letters, numbers, or hyphens.
+// Sanitization rules: https://man7.org/linux/man-pages/man5/hostname.5.html
+func sanitizeHostname(hostname string) string {
+	return hostnameRe.ReplaceAllString(hostname, "")
+}
+
 var systemParameters = map[string]func(ctx context.Context) (string, error){
 	"sys.host": func(ctx context.Context) (string, error) {
-		return os.Hostname()
+		hostname, err := os.Hostname()
+		if err != nil {
+			return "", err
+		}
+
+		return sanitizeHostname(hostname), nil
 	},
 	"sys.pkg_arch": func(ctx context.Context) (string, error) {
 		if software.DefaultPackageManager == nil {

--- a/app/configuration/bundle_parameters_test.go
+++ b/app/configuration/bundle_parameters_test.go
@@ -210,3 +210,33 @@ func Test_UsersWithParameters(t *testing.T) {
 	}
 	assert.Equal(t, reports, expectedReports)
 }
+
+func Test_sanitizeHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     string
+	}{
+		{
+			name:     "valid hostname",
+			hostname: "valid-hostname",
+			want:     "valid-hostname",
+		},
+		{
+			name:     "hostname with invalid characters",
+			hostname: "invalid!hostname@",
+			want:     "invalidhostname",
+		},
+		{
+			name:     "hostname with spaces",
+			hostname: "host name with spaces",
+			want:     "hostnamewithspaces",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeHostname(tt.hostname)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/app/configuration/bundle_parameters_test.go
+++ b/app/configuration/bundle_parameters_test.go
@@ -19,11 +19,11 @@ package configuration
 import (
 	"context"
 	"net/url"
-	"os"
 	"testing"
 
 	"go.qbee.io/agent/app/inventory"
 	"go.qbee.io/agent/app/software"
+	"go.qbee.io/agent/app/utils"
 	"go.qbee.io/agent/app/utils/assert"
 	"go.qbee.io/agent/app/utils/runner"
 )
@@ -46,7 +46,7 @@ func (m *mockURLSigner) SignURL(src string) (string, error) {
 }
 
 func Test_resolveParameters(t *testing.T) {
-	hostname, err := os.Hostname()
+	hostname, err := utils.Hostname()
 	assert.NoError(t, err)
 
 	pkgArch, err := software.DefaultPackageManager.PackageArchitecture(t.Context())
@@ -209,34 +209,4 @@ func Test_UsersWithParameters(t *testing.T) {
 		"[INFO] Successfully added user '********'",
 	}
 	assert.Equal(t, reports, expectedReports)
-}
-
-func Test_sanitizeHostname(t *testing.T) {
-	tests := []struct {
-		name     string
-		hostname string
-		want     string
-	}{
-		{
-			name:     "valid hostname",
-			hostname: "valid-hostname",
-			want:     "valid-hostname",
-		},
-		{
-			name:     "hostname with invalid characters",
-			hostname: "invalid!hostname@",
-			want:     "invalidhostname",
-		},
-		{
-			name:     "hostname with spaces",
-			hostname: "host name with spaces",
-			want:     "hostnamewithspaces",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := sanitizeHostname(tt.hostname)
-			assert.Equal(t, tt.want, got)
-		})
-	}
 }

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -673,6 +673,8 @@ func resolveSourcePath(path string) (string, error) {
 		return "", fmt.Errorf("error getting hostname: %w", err)
 	}
 
+	hostname = sanitizeHostname(hostname)
+
 	path = strings.ReplaceAll(path, templateHostTag, hostname)
 
 	return path, nil

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -32,6 +32,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"go.qbee.io/agent/app/utils"
 )
 
 const (
@@ -668,12 +670,10 @@ func resolveSourcePath(path string) (string, error) {
 		return path, nil
 	}
 
-	hostname, err := os.Hostname()
+	hostname, err := utils.Hostname()
 	if err != nil {
 		return "", fmt.Errorf("error getting hostname: %w", err)
 	}
-
-	hostname = sanitizeHostname(hostname)
 
 	path = strings.ReplaceAll(path, templateHostTag, hostname)
 

--- a/app/utils/hostname.go
+++ b/app/utils/hostname.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"os"
+	"regexp"
+)
+
+var hostnameSanitizationRe = regexp.MustCompile("[^a-zA-Z0-9-]")
+
+// sanitizeHostname removes all characters from the hostname that are not letters, numbers, or hyphens.
+// Based on https://man7.org/linux/man-pages/man5/hostname.5.html, but not enforcing all rules (length, format).
+func sanitizeHostname(hostname string) string {
+	return hostnameSanitizationRe.ReplaceAllString(hostname, "")
+}
+
+// Hostname returns the sanitized hostname of the current system, removing all characters that are not letters, numbers, or hyphens.
+func Hostname() (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+
+	return sanitizeHostname(hostname), nil
+}

--- a/app/utils/hostname_test.go
+++ b/app/utils/hostname_test.go
@@ -2,8 +2,6 @@ package utils
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_sanitizeHostname(t *testing.T) {
@@ -36,7 +34,9 @@ func Test_sanitizeHostname(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := sanitizeHostname(tt.hostname)
-			assert.Equal(t, tt.want, got)
+			if tt.want != got {
+				t.Errorf("sanitizeHostname() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/app/utils/hostname_test.go
+++ b/app/utils/hostname_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_sanitizeHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     string
+	}{
+		{
+			name:     "valid hostname",
+			hostname: "valid-hostname",
+			want:     "valid-hostname",
+		},
+		{
+			name:     "hostname with invalid characters",
+			hostname: "invalid!hostname@",
+			want:     "invalidhostname",
+		},
+		{
+			name:     "uppercase",
+			hostname: "-UPPERCASE-HOSTNAME-",
+			want:     "-UPPERCASE-HOSTNAME-",
+		},
+		{
+			name:     "hostname with spaces",
+			hostname: "host name with spaces",
+			want:     "hostnamewithspaces",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeHostname(tt.hostname)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a new utility for handling hostnames in a safer and more consistent way across the codebase. Instead of using `os.Hostname()` directly, a new `utils.Hostname()` function is added that sanitizes the hostname by removing any characters that are not letters, numbers, or hyphens. The codebase is updated to use this new function wherever the system hostname is required. Unit tests for the sanitization logic are also included.

Key changes:

**Hostname sanitization utility:**
* Added `utils.Hostname()` and `sanitizeHostname()` in `app/utils/hostname.go` to return the system hostname with only allowed characters (letters, numbers, hyphens), improving consistency and security.
* Added comprehensive tests for `sanitizeHostname()` in `app/utils/hostname_test.go`.

**Refactoring to use the new utility:**
* Replaced all direct calls to `os.Hostname()` in `app/configuration/bundle_parameters.go`, `app/configuration/bundle_parameters_test.go`, and `app/configuration/file_manager.go` with `utils.Hostname()`. [[1]](diffhunk://#diff-b2d3118f3730a16c163d5446dcf2d3437d75d253553057a851a49a8e3df8affdL22-R27) [[2]](diffhunk://#diff-b2d3118f3730a16c163d5446dcf2d3437d75d253553057a851a49a8e3df8affdL82-R82) [[3]](diffhunk://#diff-d48f6a77378599b16d16608627e8740b3eeee9260eaef023e2fc994d829f6ef7L22-R26) [[4]](diffhunk://#diff-d48f6a77378599b16d16608627e8740b3eeee9260eaef023e2fc994d829f6ef7L49-R49) [[5]](diffhunk://#diff-90619c7cfbaac6a8f8267fa41ad6d29dd5100c7528f4828f88ddc948311c5326R35-R36) [[6]](diffhunk://#diff-90619c7cfbaac6a8f8267fa41ad6d29dd5100c7528f4828f88ddc948311c5326L671-R673)