### PR TITLE
Fix: Docker Compose build context Zip Slip writes outside context directory

### DIFF
--- a/app/utils/tar.go
+++ b/app/utils/tar.go
@@ -75,6 +75,16 @@ func GetTarExtension(tarPath string) string {
 
 // unpackTar unpacks a tar archive to a destination directory.
 func unpackTar(reader io.Reader, destPath string) error {
+	if err := os.MkdirAll(destPath, 0755); err != nil {
+		return err
+	}
+
+	root, err := os.OpenRoot(destPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+
 	tarReader := tar.NewReader(reader)
 
 	for {
@@ -86,29 +96,33 @@ func unpackTar(reader io.Reader, destPath string) error {
 			return err
 		}
 
-		targetPath := filepath.Clean(filepath.Join(destPath, header.Name))
-		destdirClean := filepath.Clean(destPath)
-
-		if !strings.HasPrefix(targetPath, destdirClean) {
-			return fmt.Errorf("tar entry %s is outside of destination directory %s", targetPath, destdirClean)
-		}
+		targetPath := filepath.Clean(header.Name)
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(targetPath, 0755); err != nil {
+			if err := root.MkdirAll(targetPath, 0755); err != nil {
 				return err
 			}
 		case tar.TypeReg:
-			targetFile, err := os.Create(targetPath)
-			if err != nil {
-				return err
-			}
-			defer func() { _ = targetFile.Close() }()
-
-			if _, err := io.Copy(targetFile, tarReader); err != nil {
+			if err := unpackTarFile(root, targetPath, tarReader); err != nil {
 				return err
 			}
 		}
 	}
+	return nil
+}
+
+// unpackTarFile writes a single regular file entry into the root.
+func unpackTarFile(root *os.Root, targetPath string, tarReader io.Reader) error {
+	targetFile, err := root.Create(targetPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = targetFile.Close() }()
+
+	if _, err := io.Copy(targetFile, tarReader); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/app/utils/tar_test.go
+++ b/app/utils/tar_test.go
@@ -19,6 +19,8 @@ package utils
 import (
 	"archive/tar"
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"go.qbee.io/agent/app/utils/assert"
@@ -125,4 +127,53 @@ func Test_TarZipSlip(t *testing.T) {
 		})
 	}
 
+}
+
+// Test_TarZipSlipSiblingPrefixBypass covers traversal into a sibling directory whose cleaned path
+// still shares the destination directory as a string prefix (e.g. "context" -> "context-outside").
+func Test_TarZipSlipSiblingPrefixBypass(t *testing.T) {
+	baseDir := t.TempDir()
+	destPath := filepath.Join(baseDir, "context")
+	if err := os.MkdirAll(destPath, 0755); err != nil {
+		t.Fatalf("failed to create destination directory: %v", err)
+	}
+
+	const payload = "zip-slip-sibling-prefix"
+
+	var tarBuffer bytes.Buffer
+	tw := tar.NewWriter(&tarBuffer)
+
+	dirHeader := &tar.Header{
+		Name:     "../context-outside",
+		Mode:     0755,
+		Typeflag: tar.TypeDir,
+	}
+	if err := tw.WriteHeader(dirHeader); err != nil {
+		t.Fatalf("failed to write dir header: %v", err)
+	}
+
+	fileHeader := &tar.Header{
+		Name:     "../context-outside/payload.txt",
+		Mode:     0644,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(fileHeader); err != nil {
+		t.Fatalf("failed to write file header: %v", err)
+	}
+	if _, err := tw.Write([]byte(payload)); err != nil {
+		t.Fatalf("failed to write file content: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+
+	err := unpackTar(&tarBuffer, destPath)
+
+	escapedPath := filepath.Join(baseDir, "context-outside", "payload.txt")
+	if contents, readErr := os.ReadFile(escapedPath); readErr == nil {
+		t.Fatalf("path traversal: payload was written outside destPath at %s; got %q", escapedPath, contents)
+	}
+
+	assert.NotEqual(t, err, nil)
 }

--- a/app/utils/tar_test.go
+++ b/app/utils/tar_test.go
@@ -170,7 +170,12 @@ func Test_TarZipSlipSiblingPrefixBypass(t *testing.T) {
 
 	err := unpackTar(&tarBuffer, destPath)
 
-	escapedPath := filepath.Join(baseDir, "context-outside", "payload.txt")
+	escapedDir := filepath.Join(baseDir, "context-outside")
+	if _, statErr := os.Stat(escapedDir); statErr == nil {
+		t.Fatalf("path traversal: directory was created outside destPath at %s", escapedDir)
+	}
+
+	escapedPath := filepath.Join(escapedDir, "payload.txt")
 	if contents, readErr := os.ReadFile(escapedPath); readErr == nil {
 		t.Fatalf("path traversal: payload was written outside destPath at %s; got %q", escapedPath, contents)
 	}


### PR DESCRIPTION
This pull request strengthens the security of the `unpackTar` function to prevent directory traversal (zip-slip) vulnerabilities and adds a new test to cover a specific bypass scenario. The changes ensure that extracted files cannot escape the intended destination directory, even in tricky cases where path prefixes overlap.

**Security improvements to tar extraction:**

* Refactored `unpackTar` to use `os.OpenRoot` and operate relative to a secure root directory, preventing directory traversal attacks by ensuring all file and directory creation is safely scoped inside `destPath`. (`app/utils/tar.go`, [[1]](diffhunk://#diff-2b528f14ed76a30caa4f804d54121f2d50849773e488e362a90eeee97f58b4ddR78-R87) [[2]](diffhunk://#diff-2b528f14ed76a30caa4f804d54121f2d50849773e488e362a90eeee97f58b4ddL89-R117)
* Introduced a helper function `unpackTarFile` that creates files relative to the secure root, further reducing the risk of writing outside the target directory. (`app/utils/tar.go`, [app/utils/tar.goL89-R117](diffhunk://#diff-2b528f14ed76a30caa4f804d54121f2d50849773e488e362a90eeee97f58b4ddL89-R117))

**Testing enhancements:**

* Added `Test_TarZipSlipSiblingPrefixBypass` to verify that the extraction logic correctly blocks attempts to escape the target directory using sibling directory names with overlapping prefixes (e.g., `context` vs. `context-outside`). (`app/utils/tar_test.go`, [app/utils/tar_test.goR131-R179](diffhunk://#diff-43cd1c550fd1253a99e46e8a3e74ad79540a91bae82d07913552ad4e5d3a42ffR131-R179))
* Updated imports in the test file to support the new test logic. (`app/utils/tar_test.go`, [app/utils/tar_test.goR22-R23](diffhunk://#diff-43cd1c550fd1253a99e46e8a3e74ad79540a91bae82d07913552ad4e5d3a42ffR22-R23))