### PR TITLE
DEV-3086: Fix resume download invalid range

### DIFF
--- a/app/configuration/bundle_file_distribution_test.go
+++ b/app/configuration/bundle_file_distribution_test.go
@@ -433,7 +433,10 @@ func Test_ResumeDownload(t *testing.T) {
 
 	originalHash := strings.Fields(string(r.MustExec("sha256sum", sourcePath)))[0]
 
-	partialFilePath := configuration.GetPartialDownloadFilePath(destinationPath)
+	partialFilePath := configuration.GetPartialDownloadFilePath(destinationPath, originalHash)
+
+	// a leftover partial download of the same destination, but of different contents
+	stalePartialFilePath := configuration.GetPartialDownloadFilePath(destinationPath, strings.Repeat("a", 64))
 
 	localFileRef := "file://" + sourcePath
 	agentConfig := configuration.CommittedConfig{
@@ -464,19 +467,26 @@ func Test_ResumeDownload(t *testing.T) {
 			// Remove any file from previous tests
 			r.MustExec("rm", "-f", destinationPath)
 			r.MustExec("rm", "-f", partialFilePath)
+			r.MustExec("rm", "-f", stalePartialFilePath)
 
 			// write partial file to cache, all users should be able to delete/read it
 			r.CreateFile(partialFilePath, []byte(tt.existingContents))
+			r.CreateFile(stalePartialFilePath, []byte("leftover from another revision"))
 
 			// make sure the unprivileged user can read the file if needed
 			if r.GetUnprivileged() {
 				r.MustExec("chown", runner.UnprivilegedUser+":"+runner.UnprivilegedUser, partialFilePath)
+				r.MustExec("chown", runner.UnprivilegedUser+":"+runner.UnprivilegedUser, stalePartialFilePath)
 			}
 
 			output := r.MustExec("cat", partialFilePath)
 			assert.Equal(t, string(output), tt.existingContents)
 
 			reports, _ := configuration.ExecuteTestConfigInDocker(r, agentConfig)
+
+			// partial downloads for other digests must always be cleaned up
+			_, err := r.Exec("test", "-e", stalePartialFilePath)
+			assert.NotEqual(t, err, nil)
 
 			if tt.expectSuccess {
 				output := r.MustExec("sha256sum", destinationPath)

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -155,6 +155,12 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, err
 	}
 
+	// check local file create data
+	fileCreateData, err := determineFileCreateData(dst)
+	if err != nil {
+		return false, fmt.Errorf("error determining local fs data: %w", err)
+	}
+
 	// find size of the already downloaded part if it exists
 	var offset int64
 	if fileInfo, err := os.Stat(tmpDst); err == nil {
@@ -174,13 +180,7 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 
 	// the partial download already holds the full file, so requesting more bytes would fail with HTTP 416
 	if fileMetadata.Size > 0 && offset == fileMetadata.Size {
-		return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata)
-	}
-
-	// check local file create data
-	fileCreateData, err := determineFileCreateData(dst)
-	if err != nil {
-		return false, fmt.Errorf("error determining local fs data: %w", err)
+		return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata, fileCreateData)
 	}
 
 	// check if there is enough disk space, do not check if size is zero (unknown)
@@ -219,7 +219,7 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, fmt.Errorf("error writing file %s: %w", tmpDst, err)
 	}
 
-	return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata)
+	return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata, fileCreateData)
 }
 
 // finalizePartialDownload verifies a fully downloaded partial file and moves it to its destination.
@@ -231,11 +231,12 @@ func finalizePartialDownload(
 	ctx context.Context,
 	label, src, dst, tmpDst string,
 	fileMetadata *FileMetadata,
+	fileCreateData *fileCreateData,
 ) (bool, error) {
 	fd, err := os.OpenFile(tmpDst, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return false, nil
+			return false, fmt.Errorf("partial download %s disappeared before finalization", tmpDst)
 		}
 
 		return false, fmt.Errorf("error opening partial download %s: %w", tmpDst, err)
@@ -261,6 +262,13 @@ func finalizePartialDownload(
 		// in case of error, remove the partial file
 		_ = os.Remove(tmpDst)
 		return false, fmt.Errorf("downloaded file %s is incomplete or has invalid contents", src)
+	}
+
+	if err = fd.Chown(fileCreateData.uid, fileCreateData.gid); err != nil {
+		return false, fmt.Errorf("error setting owner on %s: %w", tmpDst, err)
+	}
+	if err = fd.Chmod(fileManagerDefaultFilePermission); err != nil {
+		return false, fmt.Errorf("error setting permissions on %s: %w", tmpDst, err)
 	}
 
 	if err = os.Rename(tmpDst, dst); err != nil {
@@ -820,6 +828,10 @@ func GetPartialDownloadFilePath(path, digest string) string {
 	return filepath.Join(filepath.Dir(path), name)
 }
 
+func legacyPartialDownloadFilePath(path string) string {
+	return filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+partialDownloadSuffix)
+}
+
 // verifyNoSymlinkAncestors ensures that dirPath and every one of its ancestor components is not a
 // symlink, so that operations following this check (e.g. os.ReadDir, os.Remove) cannot be redirected
 // to a location outside of dirPath by a symlinked path component.
@@ -867,6 +879,7 @@ func removeStalePartialDownloads(dst, keep string) error {
 
 	prefix := "." + partialDownloadNameID(dst) + "."
 	keepName := filepath.Base(keep)
+	legacyName := filepath.Base(legacyPartialDownloadFilePath(dst))
 
 	for _, entry := range entries {
 		name := entry.Name()
@@ -875,7 +888,7 @@ func removeStalePartialDownloads(dst, keep string) error {
 			continue
 		}
 
-		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, partialDownloadSuffix) {
+		if name != legacyName && (!strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, partialDownloadSuffix)) {
 			continue
 		}
 

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -872,7 +872,9 @@ func removeStalePartialDownloads(dst, keep string) error {
 
 		return fmt.Errorf("error opening directory %s: %w", dirPath, err)
 	}
-	defer dir.Close()
+	defer func() {
+		_ = dir.Close()
+	}()
 
 	entries, err := dir.ReadDir(-1)
 	if err != nil {

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -223,12 +223,36 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 }
 
 // finalizePartialDownload verifies a fully downloaded partial file and moves it to its destination.
+//
+// tmpDst is opened with O_NOFOLLOW so a symlink placed at the predictable partial download path
+// cannot be verified through its target and then have that symlink (rather than a regular file)
+// installed at dst by os.Rename (CWE-59).
 func finalizePartialDownload(
 	ctx context.Context,
 	label, src, dst, tmpDst string,
 	fileMetadata *FileMetadata,
 ) (bool, error) {
-	fileReady, err := isFileReady(tmpDst, fileMetadata)
+	fd, err := os.OpenFile(tmpDst, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("error opening partial download %s: %w", tmpDst, err)
+	}
+
+	defer func() { _ = fd.Close() }()
+
+	fileInfo, err := fd.Stat()
+	if err != nil {
+		return false, fmt.Errorf("error checking partial download %s: %w", tmpDst, err)
+	}
+
+	if !fileInfo.Mode().IsRegular() {
+		return false, fmt.Errorf("refusing to finalize non-regular partial download %s", tmpDst)
+	}
+
+	fileReady, err := isFileReadyFd(fd, fileMetadata)
 	if err != nil {
 		return false, err
 	}
@@ -565,6 +589,11 @@ func isFileReady(path string, fileMetadata *FileMetadata) (bool, error) {
 
 	defer func() { _ = fd.Close() }()
 
+	return isFileReadyFd(fd, fileMetadata)
+}
+
+// isFileReadyFd returns true if the contents read from fd match fileMetadata's expected digest.
+func isFileReadyFd(fd *os.File, fileMetadata *FileMetadata) (bool, error) {
 	var expectedHexDigest string
 	var digest hash.Hash
 
@@ -576,7 +605,7 @@ func isFileReady(path string, fileMetadata *FileMetadata) (bool, error) {
 		digest = md5.New()
 	}
 
-	if _, err = io.Copy(digest, fd); err != nil {
+	if _, err := io.Copy(digest, fd); err != nil {
 		return false, fmt.Errorf("calculating local file checksum failed: %w", err)
 	}
 
@@ -738,22 +767,42 @@ func resolveDestinationPath(source, destination string) (string, error) {
 	return destination, nil
 }
 
-const (
-	partialDownloadSuffix = ".part"
+const partialDownloadSuffix = ".part"
 
-	// leaves room for the leading dot, the separator dot, a sha256 hex digest and the suffix within NAME_MAX
-	partialDownloadMaxBaseLength = 255 - 2 - 2*sha256.Size - len(partialDownloadSuffix)
-)
-
-// partialDownloadNamePrefix returns the file name prefix shared by all partial downloads of path.
-func partialDownloadNamePrefix(path string) string {
-	base := filepath.Base(path)
-
-	if len(base) > partialDownloadMaxBaseLength {
-		base = base[:partialDownloadMaxBaseLength]
+// isValidHexDigest reports whether digest is a well-formed hex-encoded SHA-256 or MD5 digest.
+func isValidHexDigest(digest string) bool {
+	switch len(digest) {
+	case sha256.Size * 2, md5.Size * 2:
+	default:
+		return false
 	}
 
-	return fmt.Sprintf(".%s.", base)
+	_, err := hex.DecodeString(digest)
+
+	return err == nil
+}
+
+// safeDigestComponent returns a validated, path-safe representation of digest for use in a file name.
+// Digests which don't match the expected hex-encoded SHA-256/MD5 format are hashed into a fixed-width,
+// path-safe identifier instead, so arbitrary (e.g. attacker supplied) digest values can never introduce
+// path separators or traversal sequences into the resulting file name.
+func safeDigestComponent(digest string) string {
+	if isValidHexDigest(digest) {
+		return digest
+	}
+
+	sum := sha256.Sum256([]byte(digest))
+
+	return hex.EncodeToString(sum[:])
+}
+
+// partialDownloadNameID returns a fixed-width, path-safe identifier derived from the full destination
+// basename. Being a full-length hash (rather than an ambiguous, possibly truncated, textual prefix) it
+// cannot be confused with the identifier of another, differently named, destination.
+func partialDownloadNameID(path string) string {
+	sum := sha256.Sum256([]byte(filepath.Base(path)))
+
+	return hex.EncodeToString(sum[:])
 }
 
 // GetPartialDownloadFilePath returns the file path for a partial download of a file with expected digest.
@@ -761,17 +810,51 @@ func partialDownloadNamePrefix(path string) string {
 func GetPartialDownloadFilePath(path, digest string) string {
 	if digest == "" {
 		digest = "unknown"
+	} else {
+		digest = safeDigestComponent(digest)
 	}
 
-	// produces a path like .<basename>.digest.part
-	name := partialDownloadNamePrefix(path) + digest + partialDownloadSuffix
+	// produces a path like .<destination-id>.<digest>.part
+	name := "." + partialDownloadNameID(path) + "." + digest + partialDownloadSuffix
 
 	return filepath.Join(filepath.Dir(path), name)
+}
+
+// verifyNoSymlinkAncestors ensures that dirPath and every one of its ancestor components is not a
+// symlink, so that operations following this check (e.g. os.ReadDir, os.Remove) cannot be redirected
+// to a location outside of dirPath by a symlinked path component.
+func verifyNoSymlinkAncestors(dirPath string) error {
+	parent := filepath.Dir(dirPath)
+
+	if parent != dirPath {
+		if err := verifyNoSymlinkAncestors(parent); err != nil {
+			return err
+		}
+	}
+
+	info, err := os.Lstat(dirPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("error checking path %s: %w", dirPath, err)
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to traverse symlinked path component %s", dirPath)
+	}
+
+	return nil
 }
 
 // removeStalePartialDownloads removes partial downloads of dst which don't match the keep path.
 func removeStalePartialDownloads(dst, keep string) error {
 	dirPath := filepath.Dir(dst)
+
+	if err := verifyNoSymlinkAncestors(dirPath); err != nil {
+		return err
+	}
 
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
@@ -782,7 +865,7 @@ func removeStalePartialDownloads(dst, keep string) error {
 		return fmt.Errorf("error listing directory %s: %w", dirPath, err)
 	}
 
-	prefix := partialDownloadNamePrefix(dst)
+	prefix := "." + partialDownloadNameID(dst) + "."
 	keepName := filepath.Base(keep)
 
 	for _, entry := range entries {

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -832,48 +832,50 @@ func legacyPartialDownloadFilePath(path string) string {
 	return filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+partialDownloadSuffix)
 }
 
-// verifyNoSymlinkAncestors ensures that dirPath and every one of its ancestor components is not a
-// symlink, so that operations following this check (e.g. os.ReadDir, os.Remove) cannot be redirected
-// to a location outside of dirPath by a symlinked path component.
-func verifyNoSymlinkAncestors(dirPath string) error {
-	parent := filepath.Dir(dirPath)
-
-	if parent != dirPath {
-		if err := verifyNoSymlinkAncestors(parent); err != nil {
-			return err
-		}
+func openDirectoryAnchored(dirPath string) (*os.File, error) {
+	dirPath = filepath.Clean(dirPath)
+	root := "."
+	if filepath.IsAbs(dirPath) {
+		root = "/"
 	}
-
-	info, err := os.Lstat(dirPath)
+	fd, err := syscall.Open(root, os.O_RDONLY|syscall.O_DIRECTORY|syscall.O_CLOEXEC, 0)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
+		return nil, err
+	}
+
+	components := strings.Split(strings.TrimPrefix(dirPath, string(filepath.Separator)), string(filepath.Separator))
+	for _, component := range components {
+		if component == "" || component == "." {
+			continue
 		}
 
-		return fmt.Errorf("error checking path %s: %w", dirPath, err)
+		next, openErr := syscall.Openat(fd, component, os.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+		_ = syscall.Close(fd)
+		if openErr != nil {
+			return nil, openErr
+		}
+		fd = next
 	}
 
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to traverse symlinked path component %s", dirPath)
-	}
-
-	return nil
+	return os.NewFile(uintptr(fd), dirPath), nil
 }
 
 // removeStalePartialDownloads removes partial downloads of dst which don't match the keep path.
 func removeStalePartialDownloads(dst, keep string) error {
 	dirPath := filepath.Dir(dst)
 
-	if err := verifyNoSymlinkAncestors(dirPath); err != nil {
-		return err
-	}
-
-	entries, err := os.ReadDir(dirPath)
+	dir, err := openDirectoryAnchored(dirPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 
+		return fmt.Errorf("error opening directory %s: %w", dirPath, err)
+	}
+	defer dir.Close()
+
+	entries, err := dir.ReadDir(-1)
+	if err != nil {
 		return fmt.Errorf("error listing directory %s: %w", dirPath, err)
 	}
 
@@ -892,7 +894,7 @@ func removeStalePartialDownloads(dst, keep string) error {
 			continue
 		}
 
-		if err = os.Remove(filepath.Join(dirPath, name)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		if err = syscall.Unlinkat(int(dir.Fd()), name); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("error removing stale partial download %s: %w", name, err)
 		}
 	}

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -93,6 +93,15 @@ func (md *FileMetadata) SHA256() string {
 	return md.Tags[fileDigestSHA256Tag]
 }
 
+// Digest returns the digest identifying the expected contents of the file.
+func (md *FileMetadata) Digest() string {
+	if digest := md.SHA256(); digest != "" {
+		return digest
+	}
+
+	return md.MD5
+}
+
 // downloadFile and return true when file was created. In case the right file already existed, return false.
 func (srv *Service) downloadFile(ctx context.Context, label, src, dst string, file File) (bool, error) {
 	var err error
@@ -138,8 +147,13 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, err
 	}
 
-	// partial download path
-	tmpDst := GetPartialDownloadFilePath(dst)
+	// partial download path, kept in the destination directory so the final move is atomic
+	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+
+	// drop partial downloads for the same destination made for a different digest
+	if err = removeStalePartialDownloads(dst, tmpDst); err != nil {
+		return false, err
+	}
 
 	// find size of the already downloaded part if it exists
 	var offset int64
@@ -156,6 +170,11 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 			return false, fmt.Errorf("error removing invalid partial download %s: %w", tmpDst, err)
 		}
 		offset = 0
+	}
+
+	// the partial download already holds the full file, so requesting more bytes would fail with HTTP 416
+	if fileMetadata.Size > 0 && offset == fileMetadata.Size {
+		return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata)
 	}
 
 	// check local file create data
@@ -196,16 +215,28 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, fmt.Errorf("error writing file %s: %w", tmpDst, err)
 	}
 
-	// check if the download to temporary file was successful
-	if fileReady, err = isFileReady(tmpDst, fileMetadata); err != nil {
+	if err = dstFile.Close(); err != nil {
+		return false, fmt.Errorf("error writing file %s: %w", tmpDst, err)
+	}
+
+	return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata)
+}
+
+// finalizePartialDownload verifies a fully downloaded partial file and moves it to its destination.
+func finalizePartialDownload(
+	ctx context.Context,
+	label, src, dst, tmpDst string,
+	fileMetadata *FileMetadata,
+) (bool, error) {
+	fileReady, err := isFileReady(tmpDst, fileMetadata)
+	if err != nil {
 		return false, err
 	}
 
 	if !fileReady {
-		err = fmt.Errorf("downloaded file %s is incomplete or has invalid contents", src)
 		// in case of error, remove the partial file
 		_ = os.Remove(tmpDst)
-		return false, err
+		return false, fmt.Errorf("downloaded file %s is incomplete or has invalid contents", src)
 	}
 
 	if err = os.Rename(tmpDst, dst); err != nil {
@@ -707,7 +738,68 @@ func resolveDestinationPath(source, destination string) (string, error) {
 	return destination, nil
 }
 
-// GetPartialDownloadFilePath returns the file path for a partial download.
-func GetPartialDownloadFilePath(path string) string {
-	return filepath.Join(filepath.Dir(path), fmt.Sprintf(".%s.part", filepath.Base(path)))
+const (
+	partialDownloadSuffix = ".part"
+
+	// leaves room for the leading dot, the separator dot, a sha256 hex digest and the suffix within NAME_MAX
+	partialDownloadMaxBaseLength = 255 - 2 - 2*sha256.Size - len(partialDownloadSuffix)
+)
+
+// partialDownloadNamePrefix returns the file name prefix shared by all partial downloads of path.
+func partialDownloadNamePrefix(path string) string {
+	base := filepath.Base(path)
+
+	if len(base) > partialDownloadMaxBaseLength {
+		base = base[:partialDownloadMaxBaseLength]
+	}
+
+	return fmt.Sprintf(".%s.", base)
+}
+
+// GetPartialDownloadFilePath returns the file path for a partial download of a file with expected digest.
+// The partial file is placed in the destination directory, so the final move is atomic.
+func GetPartialDownloadFilePath(path, digest string) string {
+	if digest == "" {
+		digest = "unknown"
+	}
+
+	// produces a path like .<basename>.digest.part
+	name := partialDownloadNamePrefix(path) + digest + partialDownloadSuffix
+
+	return filepath.Join(filepath.Dir(path), name)
+}
+
+// removeStalePartialDownloads removes partial downloads of dst which don't match the keep path.
+func removeStalePartialDownloads(dst, keep string) error {
+	dirPath := filepath.Dir(dst)
+
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("error listing directory %s: %w", dirPath, err)
+	}
+
+	prefix := partialDownloadNamePrefix(dst)
+	keepName := filepath.Base(keep)
+
+	for _, entry := range entries {
+		name := entry.Name()
+
+		if name == keepName || entry.IsDir() {
+			continue
+		}
+
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, partialDownloadSuffix) {
+			continue
+		}
+
+		if err = os.Remove(filepath.Join(dirPath, name)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("error removing stale partial download %s: %w", name, err)
+		}
+	}
+
+	return nil
 }

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -33,6 +33,8 @@ import (
 	"strings"
 	"syscall"
 
+	"golang.org/x/sys/unix"
+
 	"go.qbee.io/agent/app/utils"
 )
 
@@ -226,9 +228,9 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 
 // finalizePartialDownload verifies a fully downloaded partial file and moves it to its destination.
 //
-// tmpDst is opened with O_NOFOLLOW so a symlink placed at the predictable partial download path
-// cannot be verified through its target and then have that symlink (rather than a regular file)
-// installed at dst by os.Rename (CWE-59).
+// tmpDst is opened with O_NOFOLLOW to verify the file without following symlinks. To prevent a
+// TOCTOU race where tmpDst is replaced after verification, the verified inode is linked to a
+// staging path (or copied via a private staging directory) and atomically renamed to dst.
 func finalizePartialDownload(
 	ctx context.Context,
 	label, src, dst, tmpDst string,
@@ -273,13 +275,68 @@ func finalizePartialDownload(
 		return false, fmt.Errorf("error setting permissions on %s: %w", tmpDst, err)
 	}
 
-	if err = os.Rename(tmpDst, dst); err != nil {
-		return false, fmt.Errorf("error renaming file %s to %s: %w", tmpDst, dst, err)
+	if err = publishVerifiedFd(fd, dst); err != nil {
+		return false, fmt.Errorf("error publishing verified file to %s: %w", dst, err)
 	}
+
+	_ = os.Remove(tmpDst)
 
 	ReportInfo(ctx, nil, msgWithLabel(label, "Successfully downloaded file %s to %s"), src, dst)
 
 	return true, nil
+}
+
+// publishVerifiedFd publishes the verified inode bound to fd to dst atomically.
+// It uses unix.Linkat to hard-link fd's inode to a staging path in dst's directory
+// and then renames it to dst. If linkat is unsupported, it falls back to copying from fd
+// via a private staging directory before renaming.
+func publishVerifiedFd(fd *os.File, dst string) error {
+	dstDir := filepath.Dir(dst)
+	stagingDst := filepath.Join(dstDir, fmt.Sprintf(".%s.verified.%d", partialDownloadNameID(dst), os.Getpid()))
+
+	_ = os.Remove(stagingDst)
+	defer func() { _ = os.Remove(stagingDst) }()
+
+	linkErr := unix.Linkat(int(fd.Fd()), "", unix.AT_FDCWD, stagingDst, unix.AT_EMPTY_PATH)
+	if linkErr == nil {
+		return os.Rename(stagingDst, dst)
+	}
+
+	// Fallback for filesystems that do not support hard links
+	stagingDir, err := os.MkdirTemp(dstDir, ".qbee-staging-*")
+	if err != nil {
+		return fmt.Errorf("failed to create staging directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(stagingDir) }()
+
+	stagingFile := filepath.Join(stagingDir, "file")
+	out, err := os.OpenFile(stagingFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fileManagerDefaultFilePermission)
+	if err != nil {
+		return fmt.Errorf("failed to create file in staging directory: %w", err)
+	}
+
+	if _, err = fd.Seek(0, io.SeekStart); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("failed to seek in verified file: %w", err)
+	}
+
+	if _, err = io.Copy(out, fd); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("failed to copy verified file content: %w", err)
+	}
+
+	stat, err := fd.Stat()
+	if err == nil {
+		if fileStat, ok := stat.Sys().(*syscall.Stat_t); ok {
+			_ = out.Chown(int(fileStat.Uid), int(fileStat.Gid))
+		}
+	}
+
+	if err = out.Close(); err != nil {
+		return fmt.Errorf("failed to close staging file: %w", err)
+	}
+
+	return os.Rename(stagingFile, dst)
 }
 
 const localFileSchema = "file://"

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -18,10 +18,18 @@ package configuration
 
 import (
 	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func Test_renderTemplate(t *testing.T) {
@@ -332,4 +340,127 @@ func Test_createFile_doesNotFollowSymlinks(t *testing.T) {
 				victimFile, victimContent, got)
 		}
 	})
+}
+
+func Test_GetPartialDownloadFilePath(t *testing.T) {
+	t.Run("includes the digest and stays in the destination directory", func(t *testing.T) {
+		got := GetPartialDownloadFilePath("/var/lib/test.txt", "abc123")
+		assert.Equal(t, got, "/var/lib/.test.txt.abc123.part")
+	})
+
+	t.Run("different digests produce different paths", func(t *testing.T) {
+		a := GetPartialDownloadFilePath("/var/lib/test.txt", "abc123")
+		b := GetPartialDownloadFilePath("/var/lib/test.txt", "def456")
+		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("file name stays within NAME_MAX", func(t *testing.T) {
+		longName := strings.Repeat("a", 300)
+		got := filepath.Base(GetPartialDownloadFilePath("/var/lib/"+longName, strings.Repeat("f", 64)))
+		assert.False(t, len(got) > 255)
+	})
+}
+
+func Test_downloadMetadataCompare_DestinationNameExceedingNameMax(t *testing.T) {
+	tempDir := t.TempDir()
+
+	contents := []byte("this is the contents of the file")
+	srcPath := filepath.Join(tempDir, "source.txt")
+
+	assert.NoError(t, os.WriteFile(srcPath, contents, 0600))
+	// a valid destination name which would exceed NAME_MAX once the digest and suffix are appended
+	dst := filepath.Join(tempDir, strings.Repeat("a", 250)+".txt")
+
+	fileMetadata := &FileMetadata{
+		Tags: map[string]string{fileDigestSHA256Tag: sha256Hex(contents)},
+		Size: int64(len(contents)),
+	}
+	name := filepath.Base(GetPartialDownloadFilePath(dst, fileMetadata.Digest()))
+	assert.False(t, len(name) > 255)
+
+	srv := new(Service)
+
+	created, err := srv.downloadMetadataCompare(context.Background(), "", "file://"+srcPath, dst, fileMetadata)
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	got, err := os.ReadFile(dst)
+	assert.NoError(t, err)
+	assert.Equal(t, contents, got)
+}
+
+func sha256Hex(contents []byte) string {
+	digest := sha256.Sum256(contents)
+
+	return hex.EncodeToString(digest[:])
+}
+
+func Test_downloadMetadataCompare_CompletePartialIsNotDownloadedAgain(t *testing.T) {
+	tempDir := t.TempDir()
+	dst := filepath.Join(tempDir, "file.txt")
+	contents := []byte("this is the contents of the file")
+
+	fileMetadata := &FileMetadata{
+		Tags: map[string]string{fileDigestSHA256Tag: sha256Hex(contents)},
+		Size: int64(len(contents)),
+	}
+
+	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+	assert.NoError(t, os.WriteFile(tmpDst, contents, 0600))
+
+	// a source which cannot be read at all - the fully downloaded partial file must be
+	// verified and renamed without touching the source
+	src := "file://" + filepath.Join(tempDir, "does-not-exist")
+	srv := new(Service)
+
+	created, err := srv.downloadMetadataCompare(context.Background(), "", src, dst, fileMetadata)
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	got, err := os.ReadFile(dst)
+	assert.NoError(t, err)
+	assert.Equal(t, contents, got)
+
+	_, err = os.Stat(tmpDst)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
+func Test_downloadMetadataCompare_RemovesPartialDownloadsWithOtherDigest(t *testing.T) {
+	tempDir := t.TempDir()
+
+	srcPath := filepath.Join(tempDir, "source.txt")
+	contents := []byte("this is the contents of the file")
+	assert.NoError(t, os.WriteFile(srcPath, contents, 0600))
+
+	dst := filepath.Join(tempDir, "file.txt")
+
+	fileMetadata := &FileMetadata{
+		Tags: map[string]string{fileDigestSHA256Tag: sha256Hex(contents)},
+		Size: int64(len(contents)),
+	}
+
+	// a leftover partial download of the same destination, but of previous contents
+	stalePartial := GetPartialDownloadFilePath(dst, sha256Hex([]byte("previous contents")))
+	assert.NoError(t, os.WriteFile(stalePartial, []byte("previous"), 0600))
+
+	// an unrelated file in the same directory which must be left alone
+	unrelated := filepath.Join(tempDir, ".other.txt.abc.part")
+	assert.NoError(t, os.WriteFile(unrelated, []byte("keep me"), 0600))
+
+	srv := new(Service)
+
+	created, err := srv.downloadMetadataCompare(context.Background(), "", "file://"+srcPath, dst, fileMetadata)
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	_, err = os.Stat(stalePartial)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+
+	// this file should still exist
+	_, err = os.Stat(unrelated)
+	assert.NoError(t, err)
+
+	got, err := os.ReadFile(dst)
+	assert.NoError(t, err)
+	assert.Equal(t, contents, got)
 }

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -343,20 +343,37 @@ func Test_createFile_doesNotFollowSymlinks(t *testing.T) {
 }
 
 func Test_GetPartialDownloadFilePath(t *testing.T) {
+	validDigestA := strings.Repeat("a", sha256.Size*2)
+	validDigestB := strings.Repeat("b", sha256.Size*2)
+
 	t.Run("includes the digest and stays in the destination directory", func(t *testing.T) {
-		got := GetPartialDownloadFilePath("/var/lib/test.txt", "abc123")
-		assert.Equal(t, got, "/var/lib/.test.txt.abc123.part")
+		got := GetPartialDownloadFilePath("/var/lib/test.txt", validDigestA)
+		assert.Equal(t, filepath.Dir(got), "/var/lib")
+		assert.True(t, strings.HasSuffix(got, "."+validDigestA+".part"))
 	})
 
 	t.Run("different digests produce different paths", func(t *testing.T) {
-		a := GetPartialDownloadFilePath("/var/lib/test.txt", "abc123")
-		b := GetPartialDownloadFilePath("/var/lib/test.txt", "def456")
+		a := GetPartialDownloadFilePath("/var/lib/test.txt", validDigestA)
+		b := GetPartialDownloadFilePath("/var/lib/test.txt", validDigestB)
 		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("different destinations produce paths where neither basename is a prefix of the other", func(t *testing.T) {
+		a := filepath.Base(GetPartialDownloadFilePath("/var/lib/test.txt", validDigestA))
+		b := filepath.Base(GetPartialDownloadFilePath("/var/lib/test.txt.other", validDigestA))
+		assert.NotEqual(t, a, b)
+		assert.False(t, strings.HasPrefix(a, b) || strings.HasPrefix(b, a))
+	})
+
+	t.Run("malformed digests are hashed into a safe fixed-width identifier", func(t *testing.T) {
+		got := GetPartialDownloadFilePath("/var/lib/test.txt", "../../../etc/passwd")
+		assert.Equal(t, filepath.Dir(got), "/var/lib")
+		assert.False(t, strings.Contains(filepath.Base(got), "/"))
 	})
 
 	t.Run("file name stays within NAME_MAX", func(t *testing.T) {
 		longName := strings.Repeat("a", 300)
-		got := filepath.Base(GetPartialDownloadFilePath("/var/lib/"+longName, strings.Repeat("f", 64)))
+		got := filepath.Base(GetPartialDownloadFilePath("/var/lib/"+longName, validDigestA))
 		assert.False(t, len(got) > 255)
 	})
 }

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -518,3 +518,26 @@ func Test_removeStalePartialDownloads_RemovesLegacyName(t *testing.T) {
 	_, err := os.Stat(legacy)
 	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }
+
+func Test_publishVerifiedFd(t *testing.T) {
+	tempDir := t.TempDir()
+	tmpDst := filepath.Join(tempDir, "partial.part")
+	verifiedContent := []byte("verified file content")
+	assert.NoError(t, os.WriteFile(tmpDst, verifiedContent, 0600))
+
+	fd, err := os.OpenFile(tmpDst, os.O_RDONLY|os.O_EXCL, 0)
+	assert.NoError(t, err)
+	defer fd.Close()
+
+	// Simulate an attacker removing/replacing tmpDst after fd was opened and verified
+	assert.NoError(t, os.Remove(tmpDst))
+	assert.NoError(t, os.WriteFile(tmpDst, []byte("malicious content"), 0600))
+
+	dst := filepath.Join(tempDir, "file.txt")
+	assert.NoError(t, publishVerifiedFd(fd, dst))
+
+	got, err := os.ReadFile(dst)
+	assert.NoError(t, err)
+	assert.Equal(t, verifiedContent, got)
+}
+

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -442,6 +442,30 @@ func Test_downloadMetadataCompare_CompletePartialIsNotDownloadedAgain(t *testing
 	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
+func Test_downloadMetadataCompare_RejectsSymlinkedCompletePartial(t *testing.T) {
+	tempDir := t.TempDir()
+	dst := filepath.Join(tempDir, "file.txt")
+	target := filepath.Join(tempDir, "target.txt")
+	contents := []byte("this is the contents of the file")
+	assert.NoError(t, os.WriteFile(target, contents, 0600))
+
+	fileMetadata := &FileMetadata{
+		Tags: map[string]string{fileDigestSHA256Tag: sha256Hex(contents)},
+		Size: int64(len(contents)),
+	}
+	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+	assert.NoError(t, os.Symlink(target, tmpDst))
+
+	_, err := new(Service).downloadMetadataCompare(
+		context.Background(), "", "file://"+target, dst, fileMetadata)
+	if err == nil {
+		t.Fatal("expected symlinked partial download to be rejected")
+	}
+
+	_, err = os.Lstat(dst)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
 func Test_downloadMetadataCompare_RemovesPartialDownloadsWithOtherDigest(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -480,4 +504,17 @@ func Test_downloadMetadataCompare_RemovesPartialDownloadsWithOtherDigest(t *test
 	got, err := os.ReadFile(dst)
 	assert.NoError(t, err)
 	assert.Equal(t, contents, got)
+}
+
+func Test_removeStalePartialDownloads_RemovesLegacyName(t *testing.T) {
+	tempDir := t.TempDir()
+	dst := filepath.Join(tempDir, "file.txt")
+	legacy := legacyPartialDownloadFilePath(dst)
+	assert.NoError(t, os.WriteFile(legacy, []byte("old partial"), 0600))
+
+	keep := GetPartialDownloadFilePath(dst, strings.Repeat("a", sha256.Size*2))
+	assert.NoError(t, removeStalePartialDownloads(dst, keep))
+
+	_, err := os.Stat(legacy)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }


### PR DESCRIPTION
This pull request significantly improves the handling of partial file downloads, focusing on correctness, security, and robustness. The changes ensure that partial downloads are uniquely identified by both destination and file digest, stale partials are cleaned up, and security is improved by preventing symlink attacks. The test suite is also expanded to cover these new behaviors and edge cases.

**Partial download file handling and cleanup:**

* Partial download files are now named using both the destination and the file digest, ensuring that different versions of the same file do not conflict and that only the correct partial is used. Stale partials (for other digests) are detected and removed before resuming a download. (`GetPartialDownloadFilePath`, `removeStalePartialDownloads`, `downloadMetadataCompare`) [[1]](diffhunk://#diff-90619c7cfbaac6a8f8267fa41ad6d29dd5100c7528f4828f88ddc948311c5326L143-R164) [[2]](diffhunk://#diff-90619c7cfbaac6a8f8267fa41ad6d29dd5100c7528f4828f88ddc948311c5326L712-R906) [[3]](diffhunk://#diff-03937e26ca8d55627eab922e46e8e8ba89d1415ac9a447b09664b3993d283d14L436-R439) [[4]](diffhunk://#diff-03937e26ca8d55627eab922e46e8e8ba89d1415ac9a447b09664b3993d283d14R470-R490)

* The naming scheme for partial download files now hashes both the destination and digest, making the names path-safe and resistant to malicious input (e.g., path traversal or injection). Legacy naming is supported for cleanup. (`GetPartialDownloadFilePath`, `safeDigestComponent`, `partialDownloadNameID`, `legacyPartialDownloadFilePath`)

**Security improvements:**

* When finalizing a partial download, the code now opens the file with `O_NOFOLLOW` and verifies it is a regular file, preventing symlink attacks (CWE-59). Ownership and permissions are set atomically before moving the file into place. (`finalizePartialDownload`)

**Test coverage:**

* Adds comprehensive tests for the new partial download naming scheme, digest safety, handling of long file names, correct cleanup of stale partials, and rejection of symlinked partials. (`file_manager_test.go`)

**Code organization and helpers:**

* Refactors digest handling into a new `Digest()` method on `FileMetadata` and introduces helpers for digest validation and safe filename construction. (`SHA256`, `Digest`, `isValidHexDigest`, `safeDigestComponent`) [[1]](diffhunk://#diff-90619c7cfbaac6a8f8267fa41ad6d29dd5100c7528f4828f88ddc948311c5326R98-R106) [[2]](diffhunk://#diff-90619c7cfbaac6a8f8267fa41ad6d29dd5100c7528f4828f88ddc948311c5326L712-R906)

**Robustness and correctness:**

* Ensures that a complete partial file is not re-downloaded, and that file names never exceed `NAME_MAX`. (`downloadMetadataCompare`, tests)

These changes collectively make partial file downloads safer, more reliable, and easier to maintain.