### PR TITLE
DEV-3086: Fix resume download invalid range

### DIFF
--- a/app/configuration/bundle_file_distribution_test.go
+++ b/app/configuration/bundle_file_distribution_test.go
@@ -433,7 +433,10 @@ func Test_ResumeDownload(t *testing.T) {
 
 	originalHash := strings.Fields(string(r.MustExec("sha256sum", sourcePath)))[0]
 
-	partialFilePath := configuration.GetPartialDownloadFilePath(destinationPath)
+	partialFilePath := configuration.GetPartialDownloadFilePath(destinationPath, originalHash)
+
+	// a leftover partial download of the same destination, but of different contents
+	stalePartialFilePath := configuration.GetPartialDownloadFilePath(destinationPath, strings.Repeat("a", 64))
 
 	localFileRef := "file://" + sourcePath
 	agentConfig := configuration.CommittedConfig{
@@ -464,19 +467,26 @@ func Test_ResumeDownload(t *testing.T) {
 			// Remove any file from previous tests
 			r.MustExec("rm", "-f", destinationPath)
 			r.MustExec("rm", "-f", partialFilePath)
+			r.MustExec("rm", "-f", stalePartialFilePath)
 
 			// write partial file to cache, all users should be able to delete/read it
 			r.CreateFile(partialFilePath, []byte(tt.existingContents))
+			r.CreateFile(stalePartialFilePath, []byte("leftover from another revision"))
 
 			// make sure the unprivileged user can read the file if needed
 			if r.GetUnprivileged() {
 				r.MustExec("chown", runner.UnprivilegedUser+":"+runner.UnprivilegedUser, partialFilePath)
+				r.MustExec("chown", runner.UnprivilegedUser+":"+runner.UnprivilegedUser, stalePartialFilePath)
 			}
 
 			output := r.MustExec("cat", partialFilePath)
 			assert.Equal(t, string(output), tt.existingContents)
 
 			reports, _ := configuration.ExecuteTestConfigInDocker(r, agentConfig)
+
+			// partial downloads for other digests must always be cleaned up
+			_, err := r.Exec("test", "-e", stalePartialFilePath)
+			assert.NotEqual(t, err, nil)
 
 			if tt.expectSuccess {
 				output := r.MustExec("sha256sum", destinationPath)

--- a/app/configuration/bundle_file_distribution_test.go
+++ b/app/configuration/bundle_file_distribution_test.go
@@ -437,6 +437,7 @@ func Test_ResumeDownload(t *testing.T) {
 
 	// a leftover partial download of the same destination, but of different contents
 	stalePartialFilePath := configuration.GetPartialDownloadFilePath(destinationPath, strings.Repeat("a", 64))
+	partialDirectoryPath := filepath.Dir(partialFilePath)
 
 	localFileRef := "file://" + sourcePath
 	agentConfig := configuration.CommittedConfig{
@@ -468,6 +469,8 @@ func Test_ResumeDownload(t *testing.T) {
 			r.MustExec("rm", "-f", destinationPath)
 			r.MustExec("rm", "-f", partialFilePath)
 			r.MustExec("rm", "-f", stalePartialFilePath)
+			r.MustExec("mkdir", "-p", partialDirectoryPath)
+			r.MustExec("chmod", "0700", partialDirectoryPath)
 
 			// write partial file to cache, all users should be able to delete/read it
 			r.CreateFile(partialFilePath, []byte(tt.existingContents))
@@ -475,6 +478,7 @@ func Test_ResumeDownload(t *testing.T) {
 
 			// make sure the unprivileged user can read the file if needed
 			if r.GetUnprivileged() {
+				r.MustExec("chown", runner.UnprivilegedUser+":"+runner.UnprivilegedUser, partialDirectoryPath)
 				r.MustExec("chown", runner.UnprivilegedUser+":"+runner.UnprivilegedUser, partialFilePath)
 				r.MustExec("chown", runner.UnprivilegedUser+":"+runner.UnprivilegedUser, stalePartialFilePath)
 			}
@@ -486,6 +490,8 @@ func Test_ResumeDownload(t *testing.T) {
 
 			// partial downloads for other digests must always be cleaned up
 			_, err := r.Exec("test", "-e", stalePartialFilePath)
+			assert.NotEqual(t, err, nil)
+			_, err = r.Exec("test", "-e", partialDirectoryPath)
 			assert.NotEqual(t, err, nil)
 
 			if tt.expectSuccess {

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -155,6 +155,12 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, err
 	}
 
+	// check local file create data
+	fileCreateData, err := determineFileCreateData(dst)
+	if err != nil {
+		return false, fmt.Errorf("error determining local fs data: %w", err)
+	}
+
 	// find size of the already downloaded part if it exists
 	var offset int64
 	if fileInfo, err := os.Stat(tmpDst); err == nil {
@@ -174,13 +180,7 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 
 	// the partial download already holds the full file, so requesting more bytes would fail with HTTP 416
 	if fileMetadata.Size > 0 && offset == fileMetadata.Size {
-		return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata)
-	}
-
-	// check local file create data
-	fileCreateData, err := determineFileCreateData(dst)
-	if err != nil {
-		return false, fmt.Errorf("error determining local fs data: %w", err)
+		return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata, fileCreateData)
 	}
 
 	// check if there is enough disk space, do not check if size is zero (unknown)
@@ -219,7 +219,7 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, fmt.Errorf("error writing file %s: %w", tmpDst, err)
 	}
 
-	return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata)
+	return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata, fileCreateData)
 }
 
 // finalizePartialDownload verifies a fully downloaded partial file and moves it to its destination.
@@ -231,11 +231,12 @@ func finalizePartialDownload(
 	ctx context.Context,
 	label, src, dst, tmpDst string,
 	fileMetadata *FileMetadata,
+	fileCreateData *fileCreateData,
 ) (bool, error) {
 	fd, err := os.OpenFile(tmpDst, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return false, nil
+			return false, fmt.Errorf("partial download %s disappeared before finalization", tmpDst)
 		}
 
 		return false, fmt.Errorf("error opening partial download %s: %w", tmpDst, err)
@@ -261,6 +262,13 @@ func finalizePartialDownload(
 		// in case of error, remove the partial file
 		_ = os.Remove(tmpDst)
 		return false, fmt.Errorf("downloaded file %s is incomplete or has invalid contents", src)
+	}
+
+	if err = fd.Chown(fileCreateData.uid, fileCreateData.gid); err != nil {
+		return false, fmt.Errorf("error setting owner on %s: %w", tmpDst, err)
+	}
+	if err = fd.Chmod(fileManagerDefaultFilePermission); err != nil {
+		return false, fmt.Errorf("error setting permissions on %s: %w", tmpDst, err)
 	}
 
 	if err = os.Rename(tmpDst, dst); err != nil {
@@ -820,6 +828,10 @@ func GetPartialDownloadFilePath(path, digest string) string {
 	return filepath.Join(filepath.Dir(path), name)
 }
 
+func legacyPartialDownloadFilePath(path string) string {
+	return filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+partialDownloadSuffix)
+}
+
 // verifyNoSymlinkAncestors ensures that dirPath and every one of its ancestor components is not a
 // symlink, so that operations following this check (e.g. os.ReadDir, os.Remove) cannot be redirected
 // to a location outside of dirPath by a symlinked path component.
@@ -867,6 +879,7 @@ func removeStalePartialDownloads(dst, keep string) error {
 
 	prefix := "." + partialDownloadNameID(dst) + "."
 	keepName := filepath.Base(keep)
+	legacyName := filepath.Base(legacyPartialDownloadFilePath(dst))
 
 	for _, entry := range entries {
 		name := entry.Name()
@@ -875,7 +888,7 @@ func removeStalePartialDownloads(dst, keep string) error {
 			continue
 		}
 
-		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, partialDownloadSuffix) {
+		if name != legacyName && (!strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, partialDownloadSuffix)) {
 			continue
 		}
 

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -872,7 +872,9 @@ func removeStalePartialDownloads(dst, keep string) error {
 
 		return fmt.Errorf("error opening directory %s: %w", dirPath, err)
 	}
-	defer dir.Close()
+	defer func() {
+		_ = dir.Close()
+	}()
 
 	entries, err := dir.ReadDir(-1)
 	if err != nil {

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -223,12 +223,36 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 }
 
 // finalizePartialDownload verifies a fully downloaded partial file and moves it to its destination.
+//
+// tmpDst is opened with O_NOFOLLOW so a symlink placed at the predictable partial download path
+// cannot be verified through its target and then have that symlink (rather than a regular file)
+// installed at dst by os.Rename (CWE-59).
 func finalizePartialDownload(
 	ctx context.Context,
 	label, src, dst, tmpDst string,
 	fileMetadata *FileMetadata,
 ) (bool, error) {
-	fileReady, err := isFileReady(tmpDst, fileMetadata)
+	fd, err := os.OpenFile(tmpDst, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("error opening partial download %s: %w", tmpDst, err)
+	}
+
+	defer func() { _ = fd.Close() }()
+
+	fileInfo, err := fd.Stat()
+	if err != nil {
+		return false, fmt.Errorf("error checking partial download %s: %w", tmpDst, err)
+	}
+
+	if !fileInfo.Mode().IsRegular() {
+		return false, fmt.Errorf("refusing to finalize non-regular partial download %s", tmpDst)
+	}
+
+	fileReady, err := isFileReadyFd(fd, fileMetadata)
 	if err != nil {
 		return false, err
 	}
@@ -565,6 +589,11 @@ func isFileReady(path string, fileMetadata *FileMetadata) (bool, error) {
 
 	defer func() { _ = fd.Close() }()
 
+	return isFileReadyFd(fd, fileMetadata)
+}
+
+// isFileReadyFd returns true if the contents read from fd match fileMetadata's expected digest.
+func isFileReadyFd(fd *os.File, fileMetadata *FileMetadata) (bool, error) {
 	var expectedHexDigest string
 	var digest hash.Hash
 
@@ -576,7 +605,7 @@ func isFileReady(path string, fileMetadata *FileMetadata) (bool, error) {
 		digest = md5.New()
 	}
 
-	if _, err = io.Copy(digest, fd); err != nil {
+	if _, err := io.Copy(digest, fd); err != nil {
 		return false, fmt.Errorf("calculating local file checksum failed: %w", err)
 	}
 
@@ -738,22 +767,42 @@ func resolveDestinationPath(source, destination string) (string, error) {
 	return destination, nil
 }
 
-const (
-	partialDownloadSuffix = ".part"
+const partialDownloadSuffix = ".part"
 
-	// leaves room for the leading dot, the separator dot, a sha256 hex digest and the suffix within NAME_MAX
-	partialDownloadMaxBaseLength = 255 - 2 - 2*sha256.Size - len(partialDownloadSuffix)
-)
-
-// partialDownloadNamePrefix returns the file name prefix shared by all partial downloads of path.
-func partialDownloadNamePrefix(path string) string {
-	base := filepath.Base(path)
-
-	if len(base) > partialDownloadMaxBaseLength {
-		base = base[:partialDownloadMaxBaseLength]
+// isValidHexDigest reports whether digest is a well-formed hex-encoded SHA-256 or MD5 digest.
+func isValidHexDigest(digest string) bool {
+	switch len(digest) {
+	case sha256.Size * 2, md5.Size * 2:
+	default:
+		return false
 	}
 
-	return fmt.Sprintf(".%s.", base)
+	_, err := hex.DecodeString(digest)
+
+	return err == nil
+}
+
+// safeDigestComponent returns a validated, path-safe representation of digest for use in a file name.
+// Digests which don't match the expected hex-encoded SHA-256/MD5 format are hashed into a fixed-width,
+// path-safe identifier instead, so arbitrary (e.g. attacker supplied) digest values can never introduce
+// path separators or traversal sequences into the resulting file name.
+func safeDigestComponent(digest string) string {
+	if isValidHexDigest(digest) {
+		return digest
+	}
+
+	sum := sha256.Sum256([]byte(digest))
+
+	return hex.EncodeToString(sum[:])
+}
+
+// partialDownloadNameID returns a fixed-width, path-safe identifier derived from the full destination
+// basename. Being a full-length hash (rather than an ambiguous, possibly truncated, textual prefix) it
+// cannot be confused with the identifier of another, differently named, destination.
+func partialDownloadNameID(path string) string {
+	sum := sha256.Sum256([]byte(filepath.Base(path)))
+
+	return hex.EncodeToString(sum[:])
 }
 
 // GetPartialDownloadFilePath returns the file path for a partial download of a file with expected digest.
@@ -761,17 +810,51 @@ func partialDownloadNamePrefix(path string) string {
 func GetPartialDownloadFilePath(path, digest string) string {
 	if digest == "" {
 		digest = "unknown"
+	} else {
+		digest = safeDigestComponent(digest)
 	}
 
-	// produces a path like .<basename>.digest.part
-	name := partialDownloadNamePrefix(path) + digest + partialDownloadSuffix
+	// produces a path like .<destination-id>.<digest>.part
+	name := "." + partialDownloadNameID(path) + "." + digest + partialDownloadSuffix
 
 	return filepath.Join(filepath.Dir(path), name)
+}
+
+// verifyNoSymlinkAncestors ensures that dirPath and every one of its ancestor components is not a
+// symlink, so that operations following this check (e.g. os.ReadDir, os.Remove) cannot be redirected
+// to a location outside of dirPath by a symlinked path component.
+func verifyNoSymlinkAncestors(dirPath string) error {
+	parent := filepath.Dir(dirPath)
+
+	if parent != dirPath {
+		if err := verifyNoSymlinkAncestors(parent); err != nil {
+			return err
+		}
+	}
+
+	info, err := os.Lstat(dirPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("error checking path %s: %w", dirPath, err)
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to traverse symlinked path component %s", dirPath)
+	}
+
+	return nil
 }
 
 // removeStalePartialDownloads removes partial downloads of dst which don't match the keep path.
 func removeStalePartialDownloads(dst, keep string) error {
 	dirPath := filepath.Dir(dst)
+
+	if err := verifyNoSymlinkAncestors(dirPath); err != nil {
+		return err
+	}
 
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
@@ -782,7 +865,7 @@ func removeStalePartialDownloads(dst, keep string) error {
 		return fmt.Errorf("error listing directory %s: %w", dirPath, err)
 	}
 
-	prefix := partialDownloadNamePrefix(dst)
+	prefix := "." + partialDownloadNameID(dst) + "."
 	keepName := filepath.Base(keep)
 
 	for _, entry := range entries {

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -832,48 +832,50 @@ func legacyPartialDownloadFilePath(path string) string {
 	return filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+partialDownloadSuffix)
 }
 
-// verifyNoSymlinkAncestors ensures that dirPath and every one of its ancestor components is not a
-// symlink, so that operations following this check (e.g. os.ReadDir, os.Remove) cannot be redirected
-// to a location outside of dirPath by a symlinked path component.
-func verifyNoSymlinkAncestors(dirPath string) error {
-	parent := filepath.Dir(dirPath)
-
-	if parent != dirPath {
-		if err := verifyNoSymlinkAncestors(parent); err != nil {
-			return err
-		}
+func openDirectoryAnchored(dirPath string) (*os.File, error) {
+	dirPath = filepath.Clean(dirPath)
+	root := "."
+	if filepath.IsAbs(dirPath) {
+		root = "/"
 	}
-
-	info, err := os.Lstat(dirPath)
+	fd, err := syscall.Open(root, os.O_RDONLY|syscall.O_DIRECTORY|syscall.O_CLOEXEC, 0)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
+		return nil, err
+	}
+
+	components := strings.Split(strings.TrimPrefix(dirPath, string(filepath.Separator)), string(filepath.Separator))
+	for _, component := range components {
+		if component == "" || component == "." {
+			continue
 		}
 
-		return fmt.Errorf("error checking path %s: %w", dirPath, err)
+		next, openErr := syscall.Openat(fd, component, os.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+		_ = syscall.Close(fd)
+		if openErr != nil {
+			return nil, openErr
+		}
+		fd = next
 	}
 
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to traverse symlinked path component %s", dirPath)
-	}
-
-	return nil
+	return os.NewFile(uintptr(fd), dirPath), nil
 }
 
 // removeStalePartialDownloads removes partial downloads of dst which don't match the keep path.
 func removeStalePartialDownloads(dst, keep string) error {
 	dirPath := filepath.Dir(dst)
 
-	if err := verifyNoSymlinkAncestors(dirPath); err != nil {
-		return err
-	}
-
-	entries, err := os.ReadDir(dirPath)
+	dir, err := openDirectoryAnchored(dirPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 
+		return fmt.Errorf("error opening directory %s: %w", dirPath, err)
+	}
+	defer dir.Close()
+
+	entries, err := dir.ReadDir(-1)
+	if err != nil {
 		return fmt.Errorf("error listing directory %s: %w", dirPath, err)
 	}
 
@@ -892,7 +894,7 @@ func removeStalePartialDownloads(dst, keep string) error {
 			continue
 		}
 
-		if err = os.Remove(filepath.Join(dirPath, name)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		if err = syscall.Unlinkat(int(dir.Fd()), name); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("error removing stale partial download %s: %w", name, err)
 		}
 	}

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -93,6 +93,15 @@ func (md *FileMetadata) SHA256() string {
 	return md.Tags[fileDigestSHA256Tag]
 }
 
+// Digest returns the digest identifying the expected contents of the file.
+func (md *FileMetadata) Digest() string {
+	if digest := md.SHA256(); digest != "" {
+		return digest
+	}
+
+	return md.MD5
+}
+
 // downloadFile and return true when file was created. In case the right file already existed, return false.
 func (srv *Service) downloadFile(ctx context.Context, label, src, dst string, file File) (bool, error) {
 	var err error
@@ -138,8 +147,13 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, err
 	}
 
-	// partial download path
-	tmpDst := GetPartialDownloadFilePath(dst)
+	// partial download path, kept in the destination directory so the final move is atomic
+	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+
+	// drop partial downloads for the same destination made for a different digest
+	if err = removeStalePartialDownloads(dst, tmpDst); err != nil {
+		return false, err
+	}
 
 	// find size of the already downloaded part if it exists
 	var offset int64
@@ -156,6 +170,11 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 			return false, fmt.Errorf("error removing invalid partial download %s: %w", tmpDst, err)
 		}
 		offset = 0
+	}
+
+	// the partial download already holds the full file, so requesting more bytes would fail with HTTP 416
+	if fileMetadata.Size > 0 && offset == fileMetadata.Size {
+		return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata)
 	}
 
 	// check local file create data
@@ -196,16 +215,28 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, fmt.Errorf("error writing file %s: %w", tmpDst, err)
 	}
 
-	// check if the download to temporary file was successful
-	if fileReady, err = isFileReady(tmpDst, fileMetadata); err != nil {
+	if err = dstFile.Close(); err != nil {
+		return false, fmt.Errorf("error writing file %s: %w", tmpDst, err)
+	}
+
+	return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata)
+}
+
+// finalizePartialDownload verifies a fully downloaded partial file and moves it to its destination.
+func finalizePartialDownload(
+	ctx context.Context,
+	label, src, dst, tmpDst string,
+	fileMetadata *FileMetadata,
+) (bool, error) {
+	fileReady, err := isFileReady(tmpDst, fileMetadata)
+	if err != nil {
 		return false, err
 	}
 
 	if !fileReady {
-		err = fmt.Errorf("downloaded file %s is incomplete or has invalid contents", src)
 		// in case of error, remove the partial file
 		_ = os.Remove(tmpDst)
-		return false, err
+		return false, fmt.Errorf("downloaded file %s is incomplete or has invalid contents", src)
 	}
 
 	if err = os.Rename(tmpDst, dst); err != nil {
@@ -707,7 +738,68 @@ func resolveDestinationPath(source, destination string) (string, error) {
 	return destination, nil
 }
 
-// GetPartialDownloadFilePath returns the file path for a partial download.
-func GetPartialDownloadFilePath(path string) string {
-	return filepath.Join(filepath.Dir(path), fmt.Sprintf(".%s.part", filepath.Base(path)))
+const (
+	partialDownloadSuffix = ".part"
+
+	// leaves room for the leading dot, the separator dot, a sha256 hex digest and the suffix within NAME_MAX
+	partialDownloadMaxBaseLength = 255 - 2 - 2*sha256.Size - len(partialDownloadSuffix)
+)
+
+// partialDownloadNamePrefix returns the file name prefix shared by all partial downloads of path.
+func partialDownloadNamePrefix(path string) string {
+	base := filepath.Base(path)
+
+	if len(base) > partialDownloadMaxBaseLength {
+		base = base[:partialDownloadMaxBaseLength]
+	}
+
+	return fmt.Sprintf(".%s.", base)
+}
+
+// GetPartialDownloadFilePath returns the file path for a partial download of a file with expected digest.
+// The partial file is placed in the destination directory, so the final move is atomic.
+func GetPartialDownloadFilePath(path, digest string) string {
+	if digest == "" {
+		digest = "unknown"
+	}
+
+	// produces a path like .<basename>.digest.part
+	name := partialDownloadNamePrefix(path) + digest + partialDownloadSuffix
+
+	return filepath.Join(filepath.Dir(path), name)
+}
+
+// removeStalePartialDownloads removes partial downloads of dst which don't match the keep path.
+func removeStalePartialDownloads(dst, keep string) error {
+	dirPath := filepath.Dir(dst)
+
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("error listing directory %s: %w", dirPath, err)
+	}
+
+	prefix := partialDownloadNamePrefix(dst)
+	keepName := filepath.Base(keep)
+
+	for _, entry := range entries {
+		name := entry.Name()
+
+		if name == keepName || entry.IsDir() {
+			continue
+		}
+
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, partialDownloadSuffix) {
+			continue
+		}
+
+		if err = os.Remove(filepath.Join(dirPath, name)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("error removing stale partial download %s: %w", name, err)
+		}
+	}
+
+	return nil
 }

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -152,6 +152,7 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 	// partial download path, kept in a private directory on the destination filesystem
 	// so the final move is atomic and unprivileged users cannot replace the partial file
 	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+	partialName := filepath.Base(tmpDst)
 
 	// check local file create data
 	fileCreateData, err := determineFileCreateData(dst)
@@ -163,27 +164,33 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, err
 	}
 
-	if err = ensurePrivatePartialDownloadDirectory(tmpDst); err != nil {
+	// partialDir is the validated, agent-owned directory holding the partial file. The fd is
+	// kept open through finalization so every subsequent operation on the partial file is
+	// anchored to this directory rather than to a pathname another user could swap out.
+	partialDir, err := openPrivatePartialDownloadDirectory(tmpDst)
+	if err != nil {
 		return false, err
 	}
 
+	defer func() { _ = partialDir.Close() }()
+
 	// drop partial downloads for the same destination made for a different digest
-	if err = removeStalePartialDownloads(dst, tmpDst); err != nil {
+	if err = removeStalePartialDownloads(partialDir, partialName); err != nil {
 		return false, err
 	}
 
 	// find size of the already downloaded part if it exists
 	var offset int64
-	if fileInfo, err := os.Stat(tmpDst); err == nil {
+	if fileInfo, statErr := statAt(partialDir, partialName); statErr == nil {
 		offset = fileInfo.Size()
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		return false, fmt.Errorf("error checking partial download %s: %w", tmpDst, err)
+	} else if !errors.Is(statErr, fs.ErrNotExist) {
+		return false, fmt.Errorf("error checking partial download %s: %w", tmpDst, statErr)
 	}
 
 	// check if offset is not larger than expected file size
 	if offset > fileMetadata.Size {
 		// partial file is larger than expected, remove it and start over
-		if err = os.Remove(tmpDst); err != nil {
+		if err = syscall.Unlinkat(int(partialDir.Fd()), partialName); err != nil {
 			return false, fmt.Errorf("error removing invalid partial download %s: %w", tmpDst, err)
 		}
 		offset = 0
@@ -191,7 +198,7 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 
 	// the partial download already holds the full file, so requesting more bytes would fail with HTTP 416
 	if fileMetadata.Size > 0 && offset == fileMetadata.Size {
-		return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata, fileCreateData)
+		return finalizePartialDownload(ctx, label, src, dst, partialDir, partialName, tmpDst, fileMetadata, fileCreateData)
 	}
 
 	// check if there is enough disk space, do not check if size is zero (unknown)
@@ -209,8 +216,8 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 	defer func() { _ = srcFile.Close() }()
 
 	var dstFile *os.File
-	if dstFile, err = createFile(tmpDst, fileCreateData, fileManagerDefaultFilePermission, offset == 0); err != nil {
-		return false, err
+	if dstFile, err = createFileAt(partialDir, partialName, fileCreateData, fileManagerDefaultFilePermission, offset == 0); err != nil {
+		return false, fmt.Errorf("error creating file %s: %w", tmpDst, err)
 	}
 
 	if offset > 0 {
@@ -230,21 +237,27 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, fmt.Errorf("error writing file %s: %w", tmpDst, err)
 	}
 
-	return finalizePartialDownload(ctx, label, src, dst, tmpDst, fileMetadata, fileCreateData)
+	return finalizePartialDownload(ctx, label, src, dst, partialDir, partialName, tmpDst, fileMetadata, fileCreateData)
 }
 
 // finalizePartialDownload verifies a fully downloaded partial file and moves it to its destination.
 //
-// tmpDst is opened with O_NOFOLLOW so a symlink placed at the predictable partial download path
-// cannot be verified through its target and then have that symlink (rather than a regular file)
-// installed at dst by os.Rename (CWE-59).
+// The entry is opened for verification and later renamed relative to partialDir - the fd of the
+// validated, agent-owned private directory obtained before verification - rather than by the
+// pathname of tmpDst. Without this, another user with write access to the destination's parent
+// directory could rename the private directory aside and substitute one of their own after the
+// descriptor above is verified but before the move, causing an unverified file to be installed at
+// dst (CWE-367). Anchoring both the open and the rename to the same directory fd guarantees the
+// entry renamed is the entry that was verified, regardless of what happens to the pathname.
 func finalizePartialDownload(
 	ctx context.Context,
-	label, src, dst, tmpDst string,
+	label, src, dst string,
+	partialDir *os.File,
+	name, tmpDst string,
 	fileMetadata *FileMetadata,
 	fileCreateData *fileCreateData,
 ) (bool, error) {
-	fd, err := os.OpenFile(tmpDst, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	rawFd, err := syscall.Openat(int(partialDir.Fd()), name, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return false, fmt.Errorf("partial download %s disappeared before finalization", tmpDst)
@@ -253,6 +266,7 @@ func finalizePartialDownload(
 		return false, fmt.Errorf("error opening partial download %s: %w", tmpDst, err)
 	}
 
+	fd := os.NewFile(uintptr(rawFd), tmpDst)
 	defer func() { _ = fd.Close() }()
 
 	fileInfo, err := fd.Stat()
@@ -271,7 +285,7 @@ func finalizePartialDownload(
 
 	if !fileReady {
 		// in case of error, remove the partial file
-		_ = os.Remove(tmpDst)
+		_ = syscall.Unlinkat(int(partialDir.Fd()), name)
 		_ = removePartialDownloadDirectory(tmpDst)
 		return false, fmt.Errorf("downloaded file %s is incomplete or has invalid contents", src)
 	}
@@ -283,9 +297,17 @@ func finalizePartialDownload(
 		return false, fmt.Errorf("error setting permissions on %s: %w", tmpDst, err)
 	}
 
-	if err = os.Rename(tmpDst, dst); err != nil {
+	dstDir, err := os.Open(filepath.Dir(dst))
+	if err != nil {
+		return false, fmt.Errorf("error opening destination directory for %s: %w", dst, err)
+	}
+
+	defer func() { _ = dstDir.Close() }()
+
+	if err = syscall.Renameat(int(partialDir.Fd()), name, int(dstDir.Fd()), filepath.Base(dst)); err != nil {
 		return false, fmt.Errorf("error renaming file %s to %s: %w", tmpDst, dst, err)
 	}
+
 	if err = removePartialDownloadDirectory(tmpDst); err != nil {
 		return false, err
 	}
@@ -845,47 +867,92 @@ func GetPartialDownloadFilePath(path, digest string) string {
 	return filepath.Join(filepath.Dir(path), directory, name)
 }
 
-func legacyPartialDownloadFilePath(path string) string {
-	return filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+partialDownloadSuffix)
-}
-
-func ensurePrivatePartialDownloadDirectory(tmpDst string) error {
+// openPrivatePartialDownloadDirectory creates (if needed) and opens the private directory used to
+// hold the partial download of tmpDst, verifying it is a directory owned by the agent. The
+// returned fd is not closed here: callers keep it open through finalization so that every
+// operation on the partial file is anchored to this validated directory rather than to a
+// pathname another user could rename or replace out from under it.
+func openPrivatePartialDownloadDirectory(tmpDst string) (*os.File, error) {
 	dirPath := filepath.Dir(tmpDst)
 	parent, err := openDirectoryAnchored(filepath.Dir(dirPath))
 	if err != nil {
-		return fmt.Errorf("error opening partial download parent directory: %w", err)
+		return nil, fmt.Errorf("error opening partial download parent directory: %w", err)
 	}
 	defer func() { _ = parent.Close() }()
 
 	dirName := filepath.Base(dirPath)
 	if err = syscall.Mkdirat(int(parent.Fd()), dirName, 0700); err != nil && !errors.Is(err, fs.ErrExist) {
-		return fmt.Errorf("error creating partial download directory %s: %w", dirPath, err)
+		return nil, fmt.Errorf("error creating partial download directory %s: %w", dirPath, err)
 	}
 
 	fd, err := syscall.Openat(int(parent.Fd()), dirName,
 		os.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
 	if err != nil {
-		return fmt.Errorf("error opening partial download directory %s: %w", dirPath, err)
+		return nil, fmt.Errorf("error opening partial download directory %s: %w", dirPath, err)
 	}
 
 	dir := os.NewFile(uintptr(fd), dirPath)
-	defer func() { _ = dir.Close() }()
 
 	info, err := dir.Stat()
 	if err != nil {
-		return fmt.Errorf("error checking partial download directory %s: %w", dirPath, err)
+		_ = dir.Close()
+		return nil, fmt.Errorf("error checking partial download directory %s: %w", dirPath, err)
 	}
 
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok || !info.IsDir() || int(stat.Uid) != os.Geteuid() {
-		return fmt.Errorf("partial download directory %s is not owned by the agent", dirPath)
+		_ = dir.Close()
+		return nil, fmt.Errorf("partial download directory %s is not owned by the agent", dirPath)
 	}
 
 	if err = dir.Chmod(0700); err != nil {
-		return fmt.Errorf("error securing partial download directory %s: %w", dirPath, err)
+		_ = dir.Close()
+		return nil, fmt.Errorf("error securing partial download directory %s: %w", dirPath, err)
 	}
 
-	return nil
+	return dir, nil
+}
+
+// statAt returns file info for name, resolved relative to dir's fd rather than by pathname.
+func statAt(dir *os.File, name string) (os.FileInfo, error) {
+	fd, err := syscall.Openat(int(dir.Fd()), name, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	f := os.NewFile(uintptr(fd), name)
+	defer func() { _ = f.Close() }()
+
+	return f.Stat()
+}
+
+// createFileAt creates (or truncates) name within dir and sets its ownership, resolving the
+// entry relative to dir's fd rather than by pathname.
+func createFileAt(
+	dir *os.File,
+	name string,
+	fileCreateData *fileCreateData,
+	permission os.FileMode,
+	truncate bool,
+) (*os.File, error) {
+	openFlags := os.O_RDWR | os.O_CREATE | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
+	if truncate {
+		openFlags |= os.O_TRUNC
+	}
+
+	fd, err := syscall.Openat(int(dir.Fd()), name, openFlags, uint32(permission))
+	if err != nil {
+		return nil, err
+	}
+
+	file := os.NewFile(uintptr(fd), name)
+
+	if err = file.Chown(fileCreateData.uid, fileCreateData.gid); err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("error setting owner on %s: %w", name, err)
+	}
+
+	return file, nil
 }
 
 func removePartialDownloadDirectory(tmpDst string) error {
@@ -925,62 +992,22 @@ func openDirectoryAnchored(dirPath string) (*os.File, error) {
 	return os.NewFile(uintptr(fd), dirPath), nil
 }
 
-// removeStalePartialDownloads removes partial downloads of dst which don't match the keep path.
-func removeStalePartialDownloads(dst, keep string) error {
-	dirPath := filepath.Dir(keep)
-
-	dir, err := openDirectoryAnchored(dirPath)
+// removeStalePartialDownloads removes partial downloads within dir left over from a previous
+// attempt made for a different digest, keeping only keepName.
+func removeStalePartialDownloads(dir *os.File, keepName string) error {
+	entries, err := dir.ReadDir(-1)
 	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("error opening directory %s: %w", dirPath, err)
-		}
-	} else {
-		defer func() { _ = dir.Close() }()
-
-		entries, readErr := dir.ReadDir(-1)
-		if readErr != nil {
-			return fmt.Errorf("error listing directory %s: %w", dirPath, readErr)
-		}
-
-		keepName := filepath.Base(keep)
-		for _, entry := range entries {
-			name := entry.Name()
-			if name == keepName || entry.IsDir() || !strings.HasSuffix(name, partialDownloadSuffix) {
-				continue
-			}
-
-			if err = syscall.Unlinkat(int(dir.Fd()), name); err != nil && !errors.Is(err, fs.ErrNotExist) {
-				return fmt.Errorf("error removing stale partial download %s: %w", name, err)
-			}
-		}
+		return fmt.Errorf("error listing partial download directory: %w", err)
 	}
 
-	parentPath := filepath.Dir(dst)
-	parent, err := openDirectoryAnchored(parentPath)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil
-		}
-		return fmt.Errorf("error opening directory %s: %w", parentPath, err)
-	}
-	defer func() { _ = parent.Close() }()
-
-	entries, err := parent.ReadDir(-1)
-	if err != nil {
-		return fmt.Errorf("error listing directory %s: %w", parentPath, err)
-	}
-
-	prefix := "." + partialDownloadNameID(dst) + "."
-	legacyName := filepath.Base(legacyPartialDownloadFilePath(dst))
 	for _, entry := range entries {
 		name := entry.Name()
-		if entry.IsDir() || (name != legacyName &&
-			(!strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, partialDownloadSuffix))) {
+		if name == keepName || entry.IsDir() || !strings.HasSuffix(name, partialDownloadSuffix) {
 			continue
 		}
 
-		if err = syscall.Unlinkat(int(parent.Fd()), name); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("error removing legacy partial download %s: %w", name, err)
+		if err = syscall.Unlinkat(int(dir.Fd()), name); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("error removing stale partial download %s: %w", name, err)
 		}
 	}
 

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -967,6 +967,7 @@ func statAt(dir *os.File, name string) (os.FileInfo, error) {
 	}
 
 	return info, nil
+}
 
 // createFileAt creates (or truncates) name within dir and sets its ownership, resolving the
 // entry relative to dir's fd rather than by pathname.

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -164,7 +164,7 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 
 	// the partial download already holds the full file, so requesting more bytes would fail with HTTP 416
 	if fileMetadata.Size > 0 && partial.offset == fileMetadata.Size {
-		return finalizePartialDownload(ctx, label, src, dst, partial.directory, partial.name, partial.path, fileMetadata, fileCreateData)
+		return srv.finalizeDownloadedFile(ctx, label, src, dst, partial, fileMetadata, fileCreateData)
 	}
 
 	// check if there is enough disk space, do not check if size is zero (unknown)
@@ -177,7 +177,7 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, err
 	}
 
-	return finalizePartialDownload(ctx, label, src, dst, partial.directory, partial.name, partial.path, fileMetadata, fileCreateData)
+	return srv.finalizeDownloadedFile(ctx, label, src, dst, partial, fileMetadata, fileCreateData)
 }
 
 type partialDownload struct {
@@ -259,6 +259,26 @@ func (srv *Service) downloadPartialFile(ctx context.Context, src string, partial
 	return nil
 }
 
+func (srv *Service) finalizeDownloadedFile(
+	ctx context.Context,
+	label, src, dst string,
+	partial *partialDownload,
+	fileMetadata *FileMetadata,
+	fileCreateData *fileCreateData,
+) (bool, error) {
+	if err := finalizePartialDownload(dst, partial, fileMetadata, fileCreateData); err != nil {
+		return false, err
+	}
+
+	if err := removePartialDownloadDirectory(partial.path); err != nil {
+		ReportWarning(ctx, err, "Unable to remove partial download directory %s", filepath.Dir(partial.path))
+	}
+
+	ReportInfo(ctx, nil, msgWithLabel(label, "Successfully downloaded file %s to %s"), src, dst)
+
+	return true, nil
+}
+
 // finalizePartialDownload verifies a fully downloaded partial file and moves it to its destination.
 //
 // The entry is opened for verification and later renamed relative to partialDir - the fd of the
@@ -269,71 +289,63 @@ func (srv *Service) downloadPartialFile(ctx context.Context, src string, partial
 // dst (CWE-367). Anchoring both the open and the rename to the same directory fd guarantees the
 // entry renamed is the entry that was verified, regardless of what happens to the pathname.
 func finalizePartialDownload(
-	ctx context.Context,
-	label, src, dst string,
-	partialDir *os.File,
-	name, tmpDst string,
+	dst string,
+	partial *partialDownload,
 	fileMetadata *FileMetadata,
 	fileCreateData *fileCreateData,
-) (bool, error) {
-	rawFd, err := syscall.Openat(int(partialDir.Fd()), name, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+) error {
+	rawFd, err := syscall.Openat(int(partial.directory.Fd()), partial.name, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return false, fmt.Errorf("partial download %s disappeared before finalization", tmpDst)
+			return fmt.Errorf("partial download %s disappeared before finalization", partial.path)
 		}
 
-		return false, fmt.Errorf("error opening partial download %s: %w", tmpDst, err)
+		return fmt.Errorf("error opening partial download %s: %w", partial.path, err)
 	}
 
-	fd := os.NewFile(uintptr(rawFd), tmpDst)
+	fd := os.NewFile(uintptr(rawFd), partial.path)
 	defer func() { _ = fd.Close() }()
 
 	fileInfo, err := fd.Stat()
 	if err != nil {
-		return false, fmt.Errorf("error checking partial download %s: %w", tmpDst, err)
+		return fmt.Errorf("error checking partial download %s: %w", partial.path, err)
 	}
 
 	if !fileInfo.Mode().IsRegular() {
-		return false, fmt.Errorf("refusing to finalize non-regular partial download %s", tmpDst)
+		return fmt.Errorf("refusing to finalize non-regular partial download %s", partial.path)
 	}
 
 	fileReady, err := isFileReadyFd(fd, fileMetadata)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if !fileReady {
 		// in case of error, remove the partial file
-		_ = syscall.Unlinkat(int(partialDir.Fd()), name)
-		_ = removePartialDownloadDirectory(tmpDst)
-		return false, fmt.Errorf("downloaded file %s is incomplete or has invalid contents", src)
+		_ = syscall.Unlinkat(int(partial.directory.Fd()), partial.name)
+		_ = removePartialDownloadDirectory(partial.path)
+		return fmt.Errorf("downloaded file is incomplete or has invalid contents")
 	}
 
 	if err = fd.Chown(fileCreateData.uid, fileCreateData.gid); err != nil {
-		return false, fmt.Errorf("error setting owner on %s: %w", tmpDst, err)
+		return fmt.Errorf("error setting owner on %s: %w", partial.path, err)
 	}
 	if err = fd.Chmod(fileManagerDefaultFilePermission); err != nil {
-		return false, fmt.Errorf("error setting permissions on %s: %w", tmpDst, err)
+		return fmt.Errorf("error setting permissions on %s: %w", partial.path, err)
 	}
 
 	dstDir, err := os.Open(filepath.Dir(dst))
 	if err != nil {
-		return false, fmt.Errorf("error opening destination directory for %s: %w", dst, err)
+		return fmt.Errorf("error opening destination directory for %s: %w", dst, err)
 	}
 
 	defer func() { _ = dstDir.Close() }()
 
-	if err = syscall.Renameat(int(partialDir.Fd()), name, int(dstDir.Fd()), filepath.Base(dst)); err != nil {
-		return false, fmt.Errorf("error renaming file %s to %s: %w", tmpDst, dst, err)
+	if err = syscall.Renameat(int(partial.directory.Fd()), partial.name, int(dstDir.Fd()), filepath.Base(dst)); err != nil {
+		return fmt.Errorf("error renaming file %s to %s: %w", partial.path, dst, err)
 	}
 
-	if err = removePartialDownloadDirectory(tmpDst); err != nil {
-		ReportWarning(ctx, err, "Unable to remove partial download directory %s", filepath.Dir(tmpDst))
-	}
-
-	ReportInfo(ctx, nil, msgWithLabel(label, "Successfully downloaded file %s to %s"), src, dst)
-
-	return true, nil
+	return nil
 }
 
 const localFileSchema = "file://"

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -948,9 +948,9 @@ func openPrivatePartialDownloadDirectory(tmpDst string) (*os.File, error) {
 	return dir, nil
 }
 
-// statAt returns file info for name, resolved relative to dir's fd rather than by pathname.
+// statAt returns file info for a regular file named name, resolved relative to dir's fd.
 func statAt(dir *os.File, name string) (os.FileInfo, error) {
-	fd, err := syscall.Openat(int(dir.Fd()), name, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+	fd, err := syscall.Openat(int(dir.Fd()), name, os.O_RDONLY|syscall.O_NONBLOCK|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -958,8 +958,15 @@ func statAt(dir *os.File, name string) (os.FileInfo, error) {
 	f := os.NewFile(uintptr(fd), name)
 	defer func() { _ = f.Close() }()
 
-	return f.Stat()
-}
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("partial download %s is not a regular file", name)
+	}
+
+	return info, nil
 
 // createFileAt creates (or truncates) name within dir and sets its ownership, resolving the
 // entry relative to dir's fd rather than by pathname.

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -205,11 +205,13 @@ func preparePartialDownload(dst string, fileMetadata *FileMetadata, fileCreateDa
 		path:      path,
 	}
 
+	// remove any stale partial downloads before proceeding
 	if err = removeStalePartialDownloads(partial.directory, partial.name); err != nil {
 		_ = partial.directory.Close()
 		return nil, err
 	}
 
+	// check the current size of the partial download, if it exists
 	if fileInfo, statErr := statAt(partial.directory, partial.name); statErr == nil {
 		partial.offset = fileInfo.Size()
 	} else if !errors.Is(statErr, fs.ErrNotExist) {
@@ -217,6 +219,7 @@ func preparePartialDownload(dst string, fileMetadata *FileMetadata, fileCreateDa
 		return nil, fmt.Errorf("error checking partial download %s: %w", partial.path, statErr)
 	}
 
+	// the partial download is larger than the expected file size, it is considered invalid and will be removed.
 	if partial.offset > fileMetadata.Size {
 		if err = syscall.Unlinkat(int(partial.directory.Fd()), partial.name); err != nil {
 			_ = partial.directory.Close()
@@ -235,6 +238,7 @@ func (srv *Service) downloadPartialFile(ctx context.Context, src string, partial
 	}
 	defer func() { _ = srcFile.Close() }()
 
+	// create the destination file for the partial download
 	dstFile, err := createFileAt(partial.directory, partial.name, fileCreateData, fileManagerDefaultFilePermission, partial.offset == 0)
 	if err != nil {
 		return fmt.Errorf("error creating file %s: %w", partial.path, err)
@@ -986,6 +990,8 @@ func createFileAt(
 	return file, nil
 }
 
+// removePartialDownloadDirectory removes the directory containing the temporary destination file for a partial download.
+// assumes that the tmpDst directory is empty as this is called after renaming the partial download to its final destination.
 func removePartialDownloadDirectory(tmpDst string) error {
 	dirPath := filepath.Dir(tmpDst)
 	if err := os.Remove(dirPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -995,6 +1001,8 @@ func removePartialDownloadDirectory(tmpDst string) error {
 	return nil
 }
 
+// openDirectoryAnchored opens a directory at dirPath, resolving it relative to the filesystem root.
+// any symlinks in the path are not followed.
 func openDirectoryAnchored(dirPath string) (*os.File, error) {
 	dirPath = filepath.Clean(dirPath)
 	root := "."
@@ -1006,8 +1014,8 @@ func openDirectoryAnchored(dirPath string) (*os.File, error) {
 		return nil, err
 	}
 
-	components := strings.Split(strings.TrimPrefix(dirPath, string(filepath.Separator)), string(filepath.Separator))
-	for _, component := range components {
+	components := strings.SplitSeq(strings.TrimPrefix(dirPath, string(filepath.Separator)), string(filepath.Separator))
+	for component := range components {
 		if component == "" || component == "." {
 			continue
 		}
@@ -1037,6 +1045,7 @@ func removeStalePartialDownloads(dir *os.File, keepName string) error {
 			continue
 		}
 
+		// remove the stale partial download
 		if err = syscall.Unlinkat(int(dir.Fd()), name); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("error removing stale partial download %s: %w", name, err)
 		}

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -309,7 +309,7 @@ func finalizePartialDownload(
 	}
 
 	if err = removePartialDownloadDirectory(tmpDst); err != nil {
-		return false, err
+		ReportWarning(ctx, err, "Unable to remove partial download directory %s", filepath.Dir(tmpDst))
 	}
 
 	ReportInfo(ctx, nil, msgWithLabel(label, "Successfully downloaded file %s to %s"), src, dst)

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -220,7 +220,7 @@ func preparePartialDownload(dst string, fileMetadata *FileMetadata, fileCreateDa
 	}
 
 	// the partial download is larger than the expected file size, it is considered invalid and will be removed.
-	if partial.offset > fileMetadata.Size {
+	if fileMetadata.Size > 0 && partial.offset > fileMetadata.Size {
 		if err = syscall.Unlinkat(int(partial.directory.Fd()), partial.name); err != nil {
 			_ = partial.directory.Close()
 			return nil, fmt.Errorf("error removing invalid partial download %s: %w", partial.path, err)
@@ -338,7 +338,7 @@ func finalizePartialDownload(
 		return fmt.Errorf("error setting permissions on %s: %w", partial.path, err)
 	}
 
-	dstDir, err := os.Open(filepath.Dir(dst))
+	dstDir, err := openDirectoryAnchored(filepath.Dir(dst))
 	if err != nil {
 		return fmt.Errorf("error opening destination directory for %s: %w", dst, err)
 	}

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -149,18 +149,27 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, err
 	}
 
-	// partial download path, kept in the destination directory so the final move is atomic
+	// partial download path, kept in a private directory on the destination filesystem
+	// so the final move is atomic and unprivileged users cannot replace the partial file
 	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
-
-	// drop partial downloads for the same destination made for a different digest
-	if err = removeStalePartialDownloads(dst, tmpDst); err != nil {
-		return false, err
-	}
 
 	// check local file create data
 	fileCreateData, err := determineFileCreateData(dst)
 	if err != nil {
 		return false, fmt.Errorf("error determining local fs data: %w", err)
+	}
+
+	if err = makeDirectories(dst, fileManagerDefaultDirectoryPermission, fileCreateData.uid, fileCreateData.gid); err != nil {
+		return false, err
+	}
+
+	if err = ensurePrivatePartialDownloadDirectory(tmpDst); err != nil {
+		return false, err
+	}
+
+	// drop partial downloads for the same destination made for a different digest
+	if err = removeStalePartialDownloads(dst, tmpDst); err != nil {
+		return false, err
 	}
 
 	// find size of the already downloaded part if it exists
@@ -263,6 +272,7 @@ func finalizePartialDownload(
 	if !fileReady {
 		// in case of error, remove the partial file
 		_ = os.Remove(tmpDst)
+		_ = removePartialDownloadDirectory(tmpDst)
 		return false, fmt.Errorf("downloaded file %s is incomplete or has invalid contents", src)
 	}
 
@@ -275,6 +285,9 @@ func finalizePartialDownload(
 
 	if err = os.Rename(tmpDst, dst); err != nil {
 		return false, fmt.Errorf("error renaming file %s to %s: %w", tmpDst, dst, err)
+	}
+	if err = removePartialDownloadDirectory(tmpDst); err != nil {
+		return false, err
 	}
 
 	ReportInfo(ctx, nil, msgWithLabel(label, "Successfully downloaded file %s to %s"), src, dst)
@@ -778,6 +791,7 @@ func resolveDestinationPath(source, destination string) (string, error) {
 }
 
 const partialDownloadSuffix = ".part"
+const partialDownloadDirectorySuffix = ".qbee-partials"
 
 // isValidHexDigest reports whether digest is a well-formed hex-encoded SHA-256 or MD5 digest.
 func isValidHexDigest(digest string) bool {
@@ -816,7 +830,7 @@ func partialDownloadNameID(path string) string {
 }
 
 // GetPartialDownloadFilePath returns the file path for a partial download of a file with expected digest.
-// The partial file is placed in the destination directory, so the final move is atomic.
+// The partial file is placed in a private subdirectory on the destination filesystem.
 func GetPartialDownloadFilePath(path, digest string) string {
 	if digest == "" {
 		digest = "unknown"
@@ -824,14 +838,63 @@ func GetPartialDownloadFilePath(path, digest string) string {
 		digest = safeDigestComponent(digest)
 	}
 
-	// produces a path like .<destination-id>.<digest>.part
-	name := "." + partialDownloadNameID(path) + "." + digest + partialDownloadSuffix
+	// produces a path like .<destination-id>.qbee-partials/<digest>.part
+	directory := "." + partialDownloadNameID(path) + partialDownloadDirectorySuffix
+	name := digest + partialDownloadSuffix
 
-	return filepath.Join(filepath.Dir(path), name)
+	return filepath.Join(filepath.Dir(path), directory, name)
 }
 
 func legacyPartialDownloadFilePath(path string) string {
 	return filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+partialDownloadSuffix)
+}
+
+func ensurePrivatePartialDownloadDirectory(tmpDst string) error {
+	dirPath := filepath.Dir(tmpDst)
+	parent, err := openDirectoryAnchored(filepath.Dir(dirPath))
+	if err != nil {
+		return fmt.Errorf("error opening partial download parent directory: %w", err)
+	}
+	defer func() { _ = parent.Close() }()
+
+	dirName := filepath.Base(dirPath)
+	if err = syscall.Mkdirat(int(parent.Fd()), dirName, 0700); err != nil && !errors.Is(err, fs.ErrExist) {
+		return fmt.Errorf("error creating partial download directory %s: %w", dirPath, err)
+	}
+
+	fd, err := syscall.Openat(int(parent.Fd()), dirName,
+		os.O_RDONLY|syscall.O_DIRECTORY|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("error opening partial download directory %s: %w", dirPath, err)
+	}
+
+	dir := os.NewFile(uintptr(fd), dirPath)
+	defer func() { _ = dir.Close() }()
+
+	info, err := dir.Stat()
+	if err != nil {
+		return fmt.Errorf("error checking partial download directory %s: %w", dirPath, err)
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || !info.IsDir() || int(stat.Uid) != os.Geteuid() {
+		return fmt.Errorf("partial download directory %s is not owned by the agent", dirPath)
+	}
+
+	if err = dir.Chmod(0700); err != nil {
+		return fmt.Errorf("error securing partial download directory %s: %w", dirPath, err)
+	}
+
+	return nil
+}
+
+func removePartialDownloadDirectory(tmpDst string) error {
+	dirPath := filepath.Dir(tmpDst)
+	if err := os.Remove(dirPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("error removing partial download directory %s: %w", dirPath, err)
+	}
+
+	return nil
 }
 
 func openDirectoryAnchored(dirPath string) (*os.File, error) {
@@ -864,42 +927,60 @@ func openDirectoryAnchored(dirPath string) (*os.File, error) {
 
 // removeStalePartialDownloads removes partial downloads of dst which don't match the keep path.
 func removeStalePartialDownloads(dst, keep string) error {
-	dirPath := filepath.Dir(dst)
+	dirPath := filepath.Dir(keep)
 
 	dir, err := openDirectoryAnchored(dirPath)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("error opening directory %s: %w", dirPath, err)
+		}
+	} else {
+		defer func() { _ = dir.Close() }()
+
+		entries, readErr := dir.ReadDir(-1)
+		if readErr != nil {
+			return fmt.Errorf("error listing directory %s: %w", dirPath, readErr)
+		}
+
+		keepName := filepath.Base(keep)
+		for _, entry := range entries {
+			name := entry.Name()
+			if name == keepName || entry.IsDir() || !strings.HasSuffix(name, partialDownloadSuffix) {
+				continue
+			}
+
+			if err = syscall.Unlinkat(int(dir.Fd()), name); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return fmt.Errorf("error removing stale partial download %s: %w", name, err)
+			}
+		}
+	}
+
+	parentPath := filepath.Dir(dst)
+	parent, err := openDirectoryAnchored(parentPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
-
-		return fmt.Errorf("error opening directory %s: %w", dirPath, err)
+		return fmt.Errorf("error opening directory %s: %w", parentPath, err)
 	}
-	defer func() {
-		_ = dir.Close()
-	}()
+	defer func() { _ = parent.Close() }()
 
-	entries, err := dir.ReadDir(-1)
+	entries, err := parent.ReadDir(-1)
 	if err != nil {
-		return fmt.Errorf("error listing directory %s: %w", dirPath, err)
+		return fmt.Errorf("error listing directory %s: %w", parentPath, err)
 	}
 
 	prefix := "." + partialDownloadNameID(dst) + "."
-	keepName := filepath.Base(keep)
 	legacyName := filepath.Base(legacyPartialDownloadFilePath(dst))
-
 	for _, entry := range entries {
 		name := entry.Name()
-
-		if name == keepName || entry.IsDir() {
+		if entry.IsDir() || (name != legacyName &&
+			(!strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, partialDownloadSuffix))) {
 			continue
 		}
 
-		if name != legacyName && (!strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, partialDownloadSuffix)) {
-			continue
-		}
-
-		if err = syscall.Unlinkat(int(dir.Fd()), name); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("error removing stale partial download %s: %w", name, err)
+		if err = syscall.Unlinkat(int(parent.Fd()), name); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("error removing legacy partial download %s: %w", name, err)
 		}
 	}
 

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -166,6 +166,15 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 	if fileMetadata.Size > 0 && partial.offset == fileMetadata.Size {
 		return srv.finalizeDownloadedFile(ctx, label, src, dst, partial, fileMetadata, fileCreateData)
 	}
+	if fileMetadata.Size == 0 && partial.offset > 0 {
+		partialReady, readyErr := isFileReady(partial.path, fileMetadata)
+		if readyErr != nil {
+			return false, readyErr
+		}
+		if partialReady {
+			return srv.finalizeDownloadedFile(ctx, label, src, dst, partial, fileMetadata, fileCreateData)
+		}
+	}
 
 	// check if there is enough disk space, do not check if size is zero (unknown)
 	if fileMetadata.Size > 0 && fileMetadata.Size-partial.offset+freeDiskOverhead > fileCreateData.bytesAvail {

--- a/app/configuration/file_manager.go
+++ b/app/configuration/file_manager.go
@@ -149,95 +149,114 @@ func (srv *Service) downloadMetadataCompare(ctx context.Context, label, src, dst
 		return false, err
 	}
 
-	// partial download path, kept in a private directory on the destination filesystem
-	// so the final move is atomic and unprivileged users cannot replace the partial file
-	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
-	partialName := filepath.Base(tmpDst)
-
 	// check local file create data
 	fileCreateData, err := determineFileCreateData(dst)
 	if err != nil {
 		return false, fmt.Errorf("error determining local fs data: %w", err)
 	}
 
-	if err = makeDirectories(dst, fileManagerDefaultDirectoryPermission, fileCreateData.uid, fileCreateData.gid); err != nil {
-		return false, err
-	}
-
-	// partialDir is the validated, agent-owned directory holding the partial file. The fd is
-	// kept open through finalization so every subsequent operation on the partial file is
-	// anchored to this directory rather than to a pathname another user could swap out.
-	partialDir, err := openPrivatePartialDownloadDirectory(tmpDst)
+	partial, err := preparePartialDownload(dst, fileMetadata, fileCreateData)
 	if err != nil {
 		return false, err
 	}
 
-	defer func() { _ = partialDir.Close() }()
-
-	// drop partial downloads for the same destination made for a different digest
-	if err = removeStalePartialDownloads(partialDir, partialName); err != nil {
-		return false, err
-	}
-
-	// find size of the already downloaded part if it exists
-	var offset int64
-	if fileInfo, statErr := statAt(partialDir, partialName); statErr == nil {
-		offset = fileInfo.Size()
-	} else if !errors.Is(statErr, fs.ErrNotExist) {
-		return false, fmt.Errorf("error checking partial download %s: %w", tmpDst, statErr)
-	}
-
-	// check if offset is not larger than expected file size
-	if offset > fileMetadata.Size {
-		// partial file is larger than expected, remove it and start over
-		if err = syscall.Unlinkat(int(partialDir.Fd()), partialName); err != nil {
-			return false, fmt.Errorf("error removing invalid partial download %s: %w", tmpDst, err)
-		}
-		offset = 0
-	}
+	defer func() { _ = partial.directory.Close() }()
 
 	// the partial download already holds the full file, so requesting more bytes would fail with HTTP 416
-	if fileMetadata.Size > 0 && offset == fileMetadata.Size {
-		return finalizePartialDownload(ctx, label, src, dst, partialDir, partialName, tmpDst, fileMetadata, fileCreateData)
+	if fileMetadata.Size > 0 && partial.offset == fileMetadata.Size {
+		return finalizePartialDownload(ctx, label, src, dst, partial.directory, partial.name, partial.path, fileMetadata, fileCreateData)
 	}
 
 	// check if there is enough disk space, do not check if size is zero (unknown)
-	if fileMetadata.Size > 0 && fileMetadata.Size-offset+freeDiskOverhead > fileCreateData.bytesAvail {
+	if fileMetadata.Size > 0 && fileMetadata.Size-partial.offset+freeDiskOverhead > fileCreateData.bytesAvail {
 		return false, fmt.Errorf("not enough disk space to download file %s: need %d bytes, have %d bytes",
-			src, fileMetadata.Size-offset+freeDiskOverhead, fileCreateData.bytesAvail)
+			src, fileMetadata.Size-partial.offset+freeDiskOverhead, fileCreateData.bytesAvail)
 	}
 
-	// download the file (or remaining part of it)
-	var srcFile io.ReadCloser
-	if srcFile, err = srv.getFile(ctx, src, offset); err != nil {
+	if err = srv.downloadPartialFile(ctx, src, partial, fileCreateData); err != nil {
 		return false, err
 	}
 
-	defer func() { _ = srcFile.Close() }()
+	return finalizePartialDownload(ctx, label, src, dst, partial.directory, partial.name, partial.path, fileMetadata, fileCreateData)
+}
 
-	var dstFile *os.File
-	if dstFile, err = createFileAt(partialDir, partialName, fileCreateData, fileManagerDefaultFilePermission, offset == 0); err != nil {
-		return false, fmt.Errorf("error creating file %s: %w", tmpDst, err)
+type partialDownload struct {
+	directory *os.File
+	name      string
+	path      string
+	offset    int64
+}
+
+// preparePartialDownload creates and validates the agent-owned directory before inspecting its entry.
+func preparePartialDownload(dst string, fileMetadata *FileMetadata, fileCreateData *fileCreateData) (*partialDownload, error) {
+	if err := makeDirectories(dst, fileManagerDefaultDirectoryPermission, fileCreateData.uid, fileCreateData.gid); err != nil {
+		return nil, err
 	}
 
-	if offset > 0 {
-		if _, err := dstFile.Seek(offset, io.SeekStart); err != nil {
+	path := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+	directory, err := openPrivatePartialDownloadDirectory(path)
+	if err != nil {
+		return nil, err
+	}
+
+	partial := &partialDownload{
+		directory: directory,
+		name:      filepath.Base(path),
+		path:      path,
+	}
+
+	if err = removeStalePartialDownloads(partial.directory, partial.name); err != nil {
+		_ = partial.directory.Close()
+		return nil, err
+	}
+
+	if fileInfo, statErr := statAt(partial.directory, partial.name); statErr == nil {
+		partial.offset = fileInfo.Size()
+	} else if !errors.Is(statErr, fs.ErrNotExist) {
+		_ = partial.directory.Close()
+		return nil, fmt.Errorf("error checking partial download %s: %w", partial.path, statErr)
+	}
+
+	if partial.offset > fileMetadata.Size {
+		if err = syscall.Unlinkat(int(partial.directory.Fd()), partial.name); err != nil {
+			_ = partial.directory.Close()
+			return nil, fmt.Errorf("error removing invalid partial download %s: %w", partial.path, err)
+		}
+		partial.offset = 0
+	}
+
+	return partial, nil
+}
+
+func (srv *Service) downloadPartialFile(ctx context.Context, src string, partial *partialDownload, fileCreateData *fileCreateData) error {
+	srcFile, err := srv.getFile(ctx, src, partial.offset)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = srcFile.Close() }()
+
+	dstFile, err := createFileAt(partial.directory, partial.name, fileCreateData, fileManagerDefaultFilePermission, partial.offset == 0)
+	if err != nil {
+		return fmt.Errorf("error creating file %s: %w", partial.path, err)
+	}
+
+	if partial.offset > 0 {
+		if _, err = dstFile.Seek(partial.offset, io.SeekStart); err != nil {
 			_ = dstFile.Close()
-			return false, fmt.Errorf("error seeking in file %s: %w", tmpDst, err)
+			return fmt.Errorf("error seeking in file %s: %w", partial.path, err)
 		}
 	}
 
-	defer func() { _ = dstFile.Close() }()
-
 	if _, err = io.Copy(dstFile, srcFile); err != nil {
-		return false, fmt.Errorf("error writing file %s: %w", tmpDst, err)
+		_ = dstFile.Close()
+		return fmt.Errorf("error writing file %s: %w", partial.path, err)
 	}
 
 	if err = dstFile.Close(); err != nil {
-		return false, fmt.Errorf("error writing file %s: %w", tmpDst, err)
+		return fmt.Errorf("error writing file %s: %w", partial.path, err)
 	}
 
-	return finalizePartialDownload(ctx, label, src, dst, partialDir, partialName, tmpDst, fileMetadata, fileCreateData)
+	return nil
 }
 
 // finalizePartialDownload verifies a fully downloaded partial file and moves it to its destination.

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -18,10 +18,18 @@ package configuration
 
 import (
 	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"go.qbee.io/agent/app/utils/assert"
 )
 
 func Test_renderTemplate(t *testing.T) {
@@ -332,4 +340,127 @@ func Test_createFile_doesNotFollowSymlinks(t *testing.T) {
 				victimFile, victimContent, got)
 		}
 	})
+}
+
+func Test_GetPartialDownloadFilePath(t *testing.T) {
+	t.Run("includes the digest and stays in the destination directory", func(t *testing.T) {
+		got := GetPartialDownloadFilePath("/var/lib/test.txt", "abc123")
+		assert.Equal(t, got, "/var/lib/.test.txt.abc123.part")
+	})
+
+	t.Run("different digests produce different paths", func(t *testing.T) {
+		a := GetPartialDownloadFilePath("/var/lib/test.txt", "abc123")
+		b := GetPartialDownloadFilePath("/var/lib/test.txt", "def456")
+		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("file name stays within NAME_MAX", func(t *testing.T) {
+		longName := strings.Repeat("a", 300)
+		got := filepath.Base(GetPartialDownloadFilePath("/var/lib/"+longName, strings.Repeat("f", 64)))
+		assert.False(t, len(got) > 255)
+	})
+}
+
+func Test_downloadMetadataCompare_DestinationNameExceedingNameMax(t *testing.T) {
+	tempDir := t.TempDir()
+
+	contents := []byte("this is the contents of the file")
+	srcPath := filepath.Join(tempDir, "source.txt")
+
+	assert.NoError(t, os.WriteFile(srcPath, contents, 0600))
+	// a valid destination name which would exceed NAME_MAX once the digest and suffix are appended
+	dst := filepath.Join(tempDir, strings.Repeat("a", 250)+".txt")
+
+	fileMetadata := &FileMetadata{
+		Tags: map[string]string{fileDigestSHA256Tag: sha256Hex(contents)},
+		Size: int64(len(contents)),
+	}
+	name := filepath.Base(GetPartialDownloadFilePath(dst, fileMetadata.Digest()))
+	assert.False(t, len(name) > 255)
+
+	srv := new(Service)
+
+	created, err := srv.downloadMetadataCompare(context.Background(), "", "file://"+srcPath, dst, fileMetadata)
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	got, err := os.ReadFile(dst)
+	assert.NoError(t, err)
+	assert.Equal(t, contents, got)
+}
+
+func sha256Hex(contents []byte) string {
+	digest := sha256.Sum256(contents)
+
+	return hex.EncodeToString(digest[:])
+}
+
+func Test_downloadMetadataCompare_CompletePartialIsNotDownloadedAgain(t *testing.T) {
+	tempDir := t.TempDir()
+	dst := filepath.Join(tempDir, "file.txt")
+	contents := []byte("this is the contents of the file")
+
+	fileMetadata := &FileMetadata{
+		Tags: map[string]string{fileDigestSHA256Tag: sha256Hex(contents)},
+		Size: int64(len(contents)),
+	}
+
+	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+	assert.NoError(t, os.WriteFile(tmpDst, contents, 0600))
+
+	// a source which cannot be read at all - the fully downloaded partial file must be
+	// verified and renamed without touching the source
+	src := "file://" + filepath.Join(tempDir, "does-not-exist")
+	srv := new(Service)
+
+	created, err := srv.downloadMetadataCompare(context.Background(), "", src, dst, fileMetadata)
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	got, err := os.ReadFile(dst)
+	assert.NoError(t, err)
+	assert.Equal(t, contents, got)
+
+	_, err = os.Stat(tmpDst)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
+func Test_downloadMetadataCompare_RemovesPartialDownloadsWithOtherDigest(t *testing.T) {
+	tempDir := t.TempDir()
+
+	srcPath := filepath.Join(tempDir, "source.txt")
+	contents := []byte("this is the contents of the file")
+	assert.NoError(t, os.WriteFile(srcPath, contents, 0600))
+
+	dst := filepath.Join(tempDir, "file.txt")
+
+	fileMetadata := &FileMetadata{
+		Tags: map[string]string{fileDigestSHA256Tag: sha256Hex(contents)},
+		Size: int64(len(contents)),
+	}
+
+	// a leftover partial download of the same destination, but of previous contents
+	stalePartial := GetPartialDownloadFilePath(dst, sha256Hex([]byte("previous contents")))
+	assert.NoError(t, os.WriteFile(stalePartial, []byte("previous"), 0600))
+
+	// an unrelated file in the same directory which must be left alone
+	unrelated := filepath.Join(tempDir, ".other.txt.abc.part")
+	assert.NoError(t, os.WriteFile(unrelated, []byte("keep me"), 0600))
+
+	srv := new(Service)
+
+	created, err := srv.downloadMetadataCompare(context.Background(), "", "file://"+srcPath, dst, fileMetadata)
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	_, err = os.Stat(stalePartial)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+
+	// this file should still exist
+	_, err = os.Stat(unrelated)
+	assert.NoError(t, err)
+
+	got, err := os.ReadFile(dst)
+	assert.NoError(t, err)
+	assert.Equal(t, contents, got)
 }

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -343,20 +343,37 @@ func Test_createFile_doesNotFollowSymlinks(t *testing.T) {
 }
 
 func Test_GetPartialDownloadFilePath(t *testing.T) {
+	validDigestA := strings.Repeat("a", sha256.Size*2)
+	validDigestB := strings.Repeat("b", sha256.Size*2)
+
 	t.Run("includes the digest and stays in the destination directory", func(t *testing.T) {
-		got := GetPartialDownloadFilePath("/var/lib/test.txt", "abc123")
-		assert.Equal(t, got, "/var/lib/.test.txt.abc123.part")
+		got := GetPartialDownloadFilePath("/var/lib/test.txt", validDigestA)
+		assert.Equal(t, filepath.Dir(got), "/var/lib")
+		assert.True(t, strings.HasSuffix(got, "."+validDigestA+".part"))
 	})
 
 	t.Run("different digests produce different paths", func(t *testing.T) {
-		a := GetPartialDownloadFilePath("/var/lib/test.txt", "abc123")
-		b := GetPartialDownloadFilePath("/var/lib/test.txt", "def456")
+		a := GetPartialDownloadFilePath("/var/lib/test.txt", validDigestA)
+		b := GetPartialDownloadFilePath("/var/lib/test.txt", validDigestB)
 		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("different destinations produce paths where neither basename is a prefix of the other", func(t *testing.T) {
+		a := filepath.Base(GetPartialDownloadFilePath("/var/lib/test.txt", validDigestA))
+		b := filepath.Base(GetPartialDownloadFilePath("/var/lib/test.txt.other", validDigestA))
+		assert.NotEqual(t, a, b)
+		assert.False(t, strings.HasPrefix(a, b) || strings.HasPrefix(b, a))
+	})
+
+	t.Run("malformed digests are hashed into a safe fixed-width identifier", func(t *testing.T) {
+		got := GetPartialDownloadFilePath("/var/lib/test.txt", "../../../etc/passwd")
+		assert.Equal(t, filepath.Dir(got), "/var/lib")
+		assert.False(t, strings.Contains(filepath.Base(got), "/"))
 	})
 
 	t.Run("file name stays within NAME_MAX", func(t *testing.T) {
 		longName := strings.Repeat("a", 300)
-		got := filepath.Base(GetPartialDownloadFilePath("/var/lib/"+longName, strings.Repeat("f", 64)))
+		got := filepath.Base(GetPartialDownloadFilePath("/var/lib/"+longName, validDigestA))
 		assert.False(t, len(got) > 255)
 	})
 }

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -442,6 +442,30 @@ func Test_downloadMetadataCompare_CompletePartialIsNotDownloadedAgain(t *testing
 	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
+func Test_downloadMetadataCompare_RejectsSymlinkedCompletePartial(t *testing.T) {
+	tempDir := t.TempDir()
+	dst := filepath.Join(tempDir, "file.txt")
+	target := filepath.Join(tempDir, "target.txt")
+	contents := []byte("this is the contents of the file")
+	assert.NoError(t, os.WriteFile(target, contents, 0600))
+
+	fileMetadata := &FileMetadata{
+		Tags: map[string]string{fileDigestSHA256Tag: sha256Hex(contents)},
+		Size: int64(len(contents)),
+	}
+	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+	assert.NoError(t, os.Symlink(target, tmpDst))
+
+	_, err := new(Service).downloadMetadataCompare(
+		context.Background(), "", "file://"+target, dst, fileMetadata)
+	if err == nil {
+		t.Fatal("expected symlinked partial download to be rejected")
+	}
+
+	_, err = os.Lstat(dst)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
 func Test_downloadMetadataCompare_RemovesPartialDownloadsWithOtherDigest(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -480,4 +504,17 @@ func Test_downloadMetadataCompare_RemovesPartialDownloadsWithOtherDigest(t *test
 	got, err := os.ReadFile(dst)
 	assert.NoError(t, err)
 	assert.Equal(t, contents, got)
+}
+
+func Test_removeStalePartialDownloads_RemovesLegacyName(t *testing.T) {
+	tempDir := t.TempDir()
+	dst := filepath.Join(tempDir, "file.txt")
+	legacy := legacyPartialDownloadFilePath(dst)
+	assert.NoError(t, os.WriteFile(legacy, []byte("old partial"), 0600))
+
+	keep := GetPartialDownloadFilePath(dst, strings.Repeat("a", sha256.Size*2))
+	assert.NoError(t, removeStalePartialDownloads(dst, keep))
+
+	_, err := os.Stat(legacy)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -348,8 +348,8 @@ func Test_GetPartialDownloadFilePath(t *testing.T) {
 
 	t.Run("includes the digest and stays in the destination directory", func(t *testing.T) {
 		got := GetPartialDownloadFilePath("/var/lib/test.txt", validDigestA)
-		assert.Equal(t, filepath.Dir(got), "/var/lib")
-		assert.True(t, strings.HasSuffix(got, "."+validDigestA+".part"))
+		assert.Equal(t, filepath.Dir(filepath.Dir(got)), "/var/lib")
+		assert.Equal(t, filepath.Base(got), validDigestA+".part")
 	})
 
 	t.Run("different digests produce different paths", func(t *testing.T) {
@@ -359,15 +359,15 @@ func Test_GetPartialDownloadFilePath(t *testing.T) {
 	})
 
 	t.Run("different destinations produce paths where neither basename is a prefix of the other", func(t *testing.T) {
-		a := filepath.Base(GetPartialDownloadFilePath("/var/lib/test.txt", validDigestA))
-		b := filepath.Base(GetPartialDownloadFilePath("/var/lib/test.txt.other", validDigestA))
+		a := filepath.Base(filepath.Dir(GetPartialDownloadFilePath("/var/lib/test.txt", validDigestA)))
+		b := filepath.Base(filepath.Dir(GetPartialDownloadFilePath("/var/lib/test.txt.other", validDigestA)))
 		assert.NotEqual(t, a, b)
 		assert.False(t, strings.HasPrefix(a, b) || strings.HasPrefix(b, a))
 	})
 
 	t.Run("malformed digests are hashed into a safe fixed-width identifier", func(t *testing.T) {
 		got := GetPartialDownloadFilePath("/var/lib/test.txt", "../../../etc/passwd")
-		assert.Equal(t, filepath.Dir(got), "/var/lib")
+		assert.Equal(t, filepath.Dir(filepath.Dir(got)), "/var/lib")
 		assert.False(t, strings.Contains(filepath.Base(got), "/"))
 	})
 
@@ -375,6 +375,28 @@ func Test_GetPartialDownloadFilePath(t *testing.T) {
 		longName := strings.Repeat("a", 300)
 		got := filepath.Base(GetPartialDownloadFilePath("/var/lib/"+longName, validDigestA))
 		assert.False(t, len(got) > 255)
+	})
+}
+
+func Test_ensurePrivatePartialDownloadDirectory(t *testing.T) {
+	t.Run("creates private directory", func(t *testing.T) {
+		tmpDst := GetPartialDownloadFilePath(filepath.Join(t.TempDir(), "file.txt"), strings.Repeat("a", 64))
+		assert.NoError(t, ensurePrivatePartialDownloadDirectory(tmpDst))
+
+		info, err := os.Stat(filepath.Dir(tmpDst))
+		assert.NoError(t, err)
+		assert.Equal(t, info.Mode().Perm(), os.FileMode(0700))
+	})
+
+	t.Run("rejects symlink", func(t *testing.T) {
+		tempDir := t.TempDir()
+		tmpDst := GetPartialDownloadFilePath(filepath.Join(tempDir, "file.txt"), strings.Repeat("a", 64))
+		target := filepath.Join(tempDir, "attacker-directory")
+		assert.NoError(t, os.Mkdir(target, 0700))
+		assert.NoError(t, os.Symlink(target, filepath.Dir(tmpDst)))
+		if err := ensurePrivatePartialDownloadDirectory(tmpDst); err == nil {
+			t.Fatal("expected symlinked partial download directory to be rejected")
+		}
 	})
 }
 
@@ -423,6 +445,7 @@ func Test_downloadMetadataCompare_CompletePartialIsNotDownloadedAgain(t *testing
 	}
 
 	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+	assert.NoError(t, os.Mkdir(filepath.Dir(tmpDst), 0700))
 	assert.NoError(t, os.WriteFile(tmpDst, contents, 0600))
 
 	// a source which cannot be read at all - the fully downloaded partial file must be
@@ -440,6 +463,8 @@ func Test_downloadMetadataCompare_CompletePartialIsNotDownloadedAgain(t *testing
 
 	_, err = os.Stat(tmpDst)
 	assert.True(t, errors.Is(err, fs.ErrNotExist))
+	_, err = os.Stat(filepath.Dir(tmpDst))
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
 func Test_downloadMetadataCompare_RejectsSymlinkedCompletePartial(t *testing.T) {
@@ -454,6 +479,7 @@ func Test_downloadMetadataCompare_RejectsSymlinkedCompletePartial(t *testing.T) 
 		Size: int64(len(contents)),
 	}
 	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+	assert.NoError(t, os.Mkdir(filepath.Dir(tmpDst), 0700))
 	assert.NoError(t, os.Symlink(target, tmpDst))
 
 	_, err := new(Service).downloadMetadataCompare(
@@ -482,6 +508,7 @@ func Test_downloadMetadataCompare_RemovesPartialDownloadsWithOtherDigest(t *test
 
 	// a leftover partial download of the same destination, but of previous contents
 	stalePartial := GetPartialDownloadFilePath(dst, sha256Hex([]byte("previous contents")))
+	assert.NoError(t, os.Mkdir(filepath.Dir(stalePartial), 0700))
 	assert.NoError(t, os.WriteFile(stalePartial, []byte("previous"), 0600))
 
 	// an unrelated file in the same directory which must be left alone

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -378,10 +378,12 @@ func Test_GetPartialDownloadFilePath(t *testing.T) {
 	})
 }
 
-func Test_ensurePrivatePartialDownloadDirectory(t *testing.T) {
+func Test_openPrivatePartialDownloadDirectory(t *testing.T) {
 	t.Run("creates private directory", func(t *testing.T) {
 		tmpDst := GetPartialDownloadFilePath(filepath.Join(t.TempDir(), "file.txt"), strings.Repeat("a", 64))
-		assert.NoError(t, ensurePrivatePartialDownloadDirectory(tmpDst))
+		dir, err := openPrivatePartialDownloadDirectory(tmpDst)
+		assert.NoError(t, err)
+		defer func() { _ = dir.Close() }()
 
 		info, err := os.Stat(filepath.Dir(tmpDst))
 		assert.NoError(t, err)
@@ -394,7 +396,7 @@ func Test_ensurePrivatePartialDownloadDirectory(t *testing.T) {
 		target := filepath.Join(tempDir, "attacker-directory")
 		assert.NoError(t, os.Mkdir(target, 0700))
 		assert.NoError(t, os.Symlink(target, filepath.Dir(tmpDst)))
-		if err := ensurePrivatePartialDownloadDirectory(tmpDst); err == nil {
+		if _, err := openPrivatePartialDownloadDirectory(tmpDst); err == nil {
 			t.Fatal("expected symlinked partial download directory to be rejected")
 		}
 	})
@@ -531,17 +533,4 @@ func Test_downloadMetadataCompare_RemovesPartialDownloadsWithOtherDigest(t *test
 	got, err := os.ReadFile(dst)
 	assert.NoError(t, err)
 	assert.Equal(t, contents, got)
-}
-
-func Test_removeStalePartialDownloads_RemovesLegacyName(t *testing.T) {
-	tempDir := t.TempDir()
-	dst := filepath.Join(tempDir, "file.txt")
-	legacy := legacyPartialDownloadFilePath(dst)
-	assert.NoError(t, os.WriteFile(legacy, []byte("old partial"), 0600))
-
-	keep := GetPartialDownloadFilePath(dst, strings.Repeat("a", sha256.Size*2))
-	assert.NoError(t, removeStalePartialDownloads(dst, keep))
-
-	_, err := os.Stat(legacy)
-	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }

--- a/app/configuration/file_manager_test.go
+++ b/app/configuration/file_manager_test.go
@@ -469,6 +469,39 @@ func Test_downloadMetadataCompare_CompletePartialIsNotDownloadedAgain(t *testing
 	assert.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
+func Test_downloadMetadataCompare_CompleteUnknownSizePartialIsNotDownloadedAgain(t *testing.T) {
+	tempDir := t.TempDir()
+	dst := filepath.Join(tempDir, "file.txt")
+	contents := []byte("this is the contents of the file")
+
+	fileMetadata := &FileMetadata{
+		Tags: map[string]string{fileDigestSHA256Tag: sha256Hex(contents)},
+		Size: 0,
+	}
+
+	tmpDst := GetPartialDownloadFilePath(dst, fileMetadata.Digest())
+	assert.NoError(t, os.Mkdir(filepath.Dir(tmpDst), 0700))
+	assert.NoError(t, os.WriteFile(tmpDst, contents, 0600))
+
+	// a source which cannot be read at all - the fully downloaded partial file must be
+	// verified and renamed without touching the source
+	src := "file://" + filepath.Join(tempDir, "does-not-exist")
+	srv := new(Service)
+
+	created, err := srv.downloadMetadataCompare(context.Background(), "", src, dst, fileMetadata)
+	assert.NoError(t, err)
+	assert.True(t, created)
+
+	got, err := os.ReadFile(dst)
+	assert.NoError(t, err)
+	assert.Equal(t, contents, got)
+
+	_, err = os.Stat(tmpDst)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+	_, err = os.Stat(filepath.Dir(tmpDst))
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
 func Test_downloadMetadataCompare_RejectsSymlinkedCompletePartial(t *testing.T) {
 	tempDir := t.TempDir()
 	dst := filepath.Join(tempDir, "file.txt")


### PR DESCRIPTION
This pull request adds comprehensive tests for partial download file handling in the file manager, focusing on security, correctness, and cleanup behavior. It introduces tests to ensure partial downloads are correctly named, safely stored, and properly cleaned up, especially when digests or file names are malformed or manipulated. Additionally, it updates an existing test to verify that leftover partial downloads from previous digests are always removed.

Partial download file path and directory handling:

* Added `Test_GetPartialDownloadFilePath` to verify that partial download paths include the digest, remain in the correct directory, handle malformed digests safely, and keep file names within system limits.
* Added `Test_openPrivatePartialDownloadDirectory` to ensure partial download directories are created with correct permissions and that symlinked directories are rejected for security.

Partial download and cleanup logic:

* Added `Test_downloadMetadataCompare_RemovesPartialDownloadsWithOtherDigest` to confirm that stale partial downloads from previous digests are removed, while unrelated files are preserved.
* Updated `Test_ResumeDownload` to explicitly create and clean up stale partial downloads for different contents, and to check that both the stale file and its directory are deleted after a successful download. [[1]](diffhunk://#diff-03937e26ca8d55627eab922e46e8e8ba89d1415ac9a447b09664b3993d283d14L436-R440) [[2]](diffhunk://#diff-03937e26ca8d55627eab922e46e8e8ba89d1415ac9a447b09664b3993d283d14R471-R496)

Edge case and security tests:

* Added tests for edge cases such as file names exceeding `NAME_MAX`, zero-size metadata rejection, and handling of symlinked partial files to prevent security issues.

Test utility improvements:

* Added helper functions like `sha256Hex` and improved imports to support new test cases. [[1]](diffhunk://#diff-4b2871e236b0edc0e9b5b7d7e8e43c853a79f79c2c5e69419094e9425965bae8R21-R32) [[2]](diffhunk://#diff-4b2871e236b0edc0e9b5b7d7e8e43c853a79f79c2c5e69419094e9425965bae8R344-R563)