### PR TITLE
Redact docker/podman repository passwords from agent logs.

### DIFF
--- a/app/configuration/bundle_docker_compose.go
+++ b/app/configuration/bundle_docker_compose.go
@@ -177,6 +177,19 @@ func (d DockerComposeBundle) Execute(ctx context.Context, service *Service) erro
 	return nil
 }
 
+// SecretsList returns a list of all secrets.
+func (d DockerComposeBundle) SecretsList() []string {
+	var secrets []string
+
+	for _, registry := range d.RegistryAuths {
+		if registry.Password != "" {
+			secrets = append(secrets, registry.Password)
+		}
+	}
+
+	return secrets
+}
+
 // projectStatus is a project that is running in the system.
 type projectStatus struct {
 	Name   string `json:"Name"`

--- a/app/configuration/bundle_docker_compose.go
+++ b/app/configuration/bundle_docker_compose.go
@@ -178,12 +178,12 @@ func (d DockerComposeBundle) Execute(ctx context.Context, service *Service) erro
 }
 
 // SecretsList returns a list of all secrets.
-func (d DockerComposeBundle) SecretsList() []string {
+func (d DockerComposeBundle) SecretsList(ctx context.Context) []string {
 	var secrets []string
 
 	for _, registry := range d.RegistryAuths {
 		if registry.Password != "" {
-			secrets = append(secrets, registry.Password)
+			secrets = append(secrets, resolveParameters(ctx, registry.Password))
 		}
 	}
 

--- a/app/configuration/bundle_docker_containers.go
+++ b/app/configuration/bundle_docker_containers.go
@@ -98,12 +98,12 @@ func (d DockerContainersBundle) Execute(ctx context.Context, service *Service) e
 }
 
 // SecretsList returns a list of all secrets.
-func (d DockerContainersBundle) SecretsList() []string {
+func (d DockerContainersBundle) SecretsList(ctx context.Context) []string {
 	var secrets []string
 
 	for _, registry := range d.RegistryAuths {
 		if registry.Password != "" {
-			secrets = append(secrets, registry.Password)
+			secrets = append(secrets, resolveParameters(ctx, registry.Password))
 		}
 	}
 

--- a/app/configuration/bundle_docker_containers.go
+++ b/app/configuration/bundle_docker_containers.go
@@ -96,3 +96,16 @@ func (d DockerContainersBundle) Execute(ctx context.Context, service *Service) e
 
 	return nil
 }
+
+// SecretsList returns a list of all secrets.
+func (d DockerContainersBundle) SecretsList() []string {
+	var secrets []string
+
+	for _, registry := range d.RegistryAuths {
+		if registry.Password != "" {
+			secrets = append(secrets, registry.Password)
+		}
+	}
+
+	return secrets
+}

--- a/app/configuration/bundle_podman_containers.go
+++ b/app/configuration/bundle_podman_containers.go
@@ -98,12 +98,12 @@ func (p PodmanContainerBundle) Execute(ctx context.Context, service *Service) er
 }
 
 // SecretsList returns a list of all secrets.
-func (p PodmanContainerBundle) SecretsList() []string {
+func (p PodmanContainerBundle) SecretsList(ctx context.Context) []string {
 	var secrets []string
 
 	for _, registry := range p.RegistryAuths {
 		if registry.Password != "" {
-			secrets = append(secrets, registry.Password)
+			secrets = append(secrets, resolveParameters(ctx, registry.Password))
 		}
 	}
 

--- a/app/configuration/bundle_podman_containers.go
+++ b/app/configuration/bundle_podman_containers.go
@@ -96,3 +96,16 @@ func (p PodmanContainerBundle) Execute(ctx context.Context, service *Service) er
 
 	return nil
 }
+
+// SecretsList returns a list of all secrets.
+func (p PodmanContainerBundle) SecretsList() []string {
+	var secrets []string
+
+	for _, registry := range p.RegistryAuths {
+		if registry.Password != "" {
+			secrets = append(secrets, registry.Password)
+		}
+	}
+
+	return secrets
+}

--- a/app/configuration/config.go
+++ b/app/configuration/config.go
@@ -57,6 +57,29 @@ type CommittedConfig struct {
 	EdgeURL string `json:"edge_url"`
 }
 
+// SecretsList returns a list of all secret values present in the CommittedConfig.
+func (cc *CommittedConfig) SecretsList() []string {
+	var secrets []string
+
+	if cc.BundleData.Parameters != nil {
+		secrets = append(secrets, cc.BundleData.Parameters.SecretsList()...)
+	}
+
+	if cc.BundleData.DockerCompose != nil {
+		secrets = append(secrets, cc.BundleData.DockerCompose.SecretsList()...)
+	}
+
+	if cc.BundleData.DockerContainers != nil {
+		secrets = append(secrets, cc.BundleData.DockerContainers.SecretsList()...)
+	}
+
+	if cc.BundleData.PodmanContainers != nil {
+		secrets = append(secrets, cc.BundleData.PodmanContainers.SecretsList()...)
+	}
+
+	return secrets
+}
+
 // HasBundle returns true if bundleName is set in the Bundles list.
 func (cc *CommittedConfig) HasBundle(bundleName string) bool {
 	return slices.Contains(cc.Bundles, bundleName)

--- a/app/configuration/config.go
+++ b/app/configuration/config.go
@@ -16,7 +16,10 @@
 
 package configuration
 
-import "slices"
+import (
+	"context"
+	"slices"
+)
 
 // Supported configuration bundles.
 const (
@@ -58,7 +61,7 @@ type CommittedConfig struct {
 }
 
 // SecretsList returns a list of all secret values present in the CommittedConfig.
-func (cc *CommittedConfig) SecretsList() []string {
+func (cc *CommittedConfig) SecretsList(ctx context.Context) []string {
 	var secrets []string
 
 	if cc.BundleData.Parameters != nil {
@@ -66,16 +69,23 @@ func (cc *CommittedConfig) SecretsList() []string {
 	}
 
 	if cc.BundleData.DockerCompose != nil {
-		secrets = append(secrets, cc.BundleData.DockerCompose.SecretsList()...)
+		secrets = append(secrets, cc.BundleData.DockerCompose.SecretsList(ctx)...)
 	}
 
 	if cc.BundleData.DockerContainers != nil {
-		secrets = append(secrets, cc.BundleData.DockerContainers.SecretsList()...)
+		secrets = append(secrets, cc.BundleData.DockerContainers.SecretsList(ctx)...)
 	}
 
 	if cc.BundleData.PodmanContainers != nil {
-		secrets = append(secrets, cc.BundleData.PodmanContainers.SecretsList()...)
+		secrets = append(secrets, cc.BundleData.PodmanContainers.SecretsList(ctx)...)
 	}
+
+	// Sort secrets by length in descending order to avoid false-prefix-matching, e.g.:
+	// If secret is "password123", but retrned (unsorted) list is []string{"password", password123"},
+	// the secret would be then redacted as "********123" instead of "************".
+	slices.SortFunc(secrets, func(a, b string) int {
+		return len(b) - len(a)
+	})
 
 	return secrets
 }

--- a/app/configuration/config_test.go
+++ b/app/configuration/config_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 qbee.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package configuration
+
+import (
+	"testing"
+
+	"go.qbee.io/agent/app/utils/assert"
+)
+
+func TestCommittedConfig_SecretsList(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   CommittedConfig
+		expected []string
+	}{
+		{
+			name:     "no bundles",
+			config:   CommittedConfig{},
+			expected: nil,
+		},
+		{
+			name: "parameters secrets",
+			config: CommittedConfig{
+				BundleData: BundleData{
+					Parameters: &ParametersBundle{
+						Secrets: []Parameter{
+							{Key: "db_password", Value: "param-secret-1"},
+							{Key: "api_token", Value: "param-secret-2"},
+						},
+					},
+				},
+			},
+			expected: []string{"param-secret-1", "param-secret-2"},
+		},
+		{
+			name: "docker compose registry secrets",
+			config: CommittedConfig{
+				BundleData: BundleData{
+					DockerCompose: &DockerComposeBundle{
+						RegistryAuths: []RegistryAuth{
+							{Server: "gcr.io", Username: "user", Password: "compose-secret"},
+						},
+					},
+				},
+			},
+			expected: []string{"compose-secret"},
+		},
+		{
+			name: "docker containers registry secrets",
+			config: CommittedConfig{
+				BundleData: BundleData{
+					DockerContainers: &DockerContainersBundle{
+						RegistryAuths: []RegistryAuth{
+							{Server: "gcr.io", Username: "user", Password: "docker-secret"},
+						},
+					},
+				},
+			},
+			expected: []string{"docker-secret"},
+		},
+		{
+			name: "podman containers registry secrets",
+			config: CommittedConfig{
+				BundleData: BundleData{
+					PodmanContainers: &PodmanContainerBundle{
+						RegistryAuths: []RegistryAuth{
+							{Server: "gcr.io", Username: "user", Password: "podman-secret"},
+						},
+					},
+				},
+			},
+			expected: []string{"podman-secret"},
+		},
+		{
+			name: "secrets from all bundles",
+			config: CommittedConfig{
+				BundleData: BundleData{
+					Parameters: &ParametersBundle{
+						Secrets: []Parameter{
+							{Key: "db_password", Value: "param-secret"},
+						},
+					},
+					DockerCompose: &DockerComposeBundle{
+						RegistryAuths: []RegistryAuth{
+							{Server: "gcr.io", Username: "user", Password: "compose-secret"},
+						},
+					},
+					DockerContainers: &DockerContainersBundle{
+						RegistryAuths: []RegistryAuth{
+							{Server: "gcr.io", Username: "user", Password: "docker-secret"},
+						},
+					},
+					PodmanContainers: &PodmanContainerBundle{
+						RegistryAuths: []RegistryAuth{
+							{Server: "gcr.io", Username: "user", Password: "podman-secret"},
+						},
+					},
+				},
+			},
+			expected: []string{"param-secret", "compose-secret", "docker-secret", "podman-secret"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.config.SecretsList(), tt.expected)
+		})
+	}
+}

--- a/app/configuration/config_test.go
+++ b/app/configuration/config_test.go
@@ -17,6 +17,7 @@
 package configuration
 
 import (
+	"context"
 	"testing"
 
 	"go.qbee.io/agent/app/utils/assert"
@@ -24,7 +25,12 @@ import (
 
 func TestCommittedConfig_SecretsList(t *testing.T) {
 	tests := []struct {
-		name     string
+		name string
+
+		// storeSecrets are placed in the resolution context, so registry passwords
+		// referencing them via $(key) can be resolved.
+		storeSecrets []Parameter
+
 		config   CommittedConfig
 		expected []string
 	}{
@@ -39,86 +45,120 @@ func TestCommittedConfig_SecretsList(t *testing.T) {
 				BundleData: BundleData{
 					Parameters: &ParametersBundle{
 						Secrets: []Parameter{
-							{Key: "db_password", Value: "param-secret-1"},
-							{Key: "api_token", Value: "param-secret-2"},
+							{Key: "db_password", Value: "param-secret-longest"},
+							{Key: "api_token", Value: "param-secret-mid"},
 						},
 					},
 				},
 			},
-			expected: []string{"param-secret-1", "param-secret-2"},
+			expected: []string{"param-secret-longest", "param-secret-mid"},
 		},
 		{
-			name: "docker compose registry secrets",
+			name: "docker compose registry secret resolved from parameter",
+			storeSecrets: []Parameter{
+				{Key: "compose_registry_password", Value: "resolved-compose-secret"},
+			},
 			config: CommittedConfig{
 				BundleData: BundleData{
 					DockerCompose: &DockerComposeBundle{
 						RegistryAuths: []RegistryAuth{
-							{Server: "gcr.io", Username: "user", Password: "compose-secret"},
+							{Server: "gcr.io", Username: "user", Password: "$(compose_registry_password)"},
 						},
 					},
 				},
 			},
-			expected: []string{"compose-secret"},
+			expected: []string{"resolved-compose-secret"},
 		},
 		{
-			name: "docker containers registry secrets",
+			name: "docker containers registry secret resolved from parameter",
+			storeSecrets: []Parameter{
+				{Key: "docker_registry_password", Value: "resolved-docker-secret"},
+			},
 			config: CommittedConfig{
 				BundleData: BundleData{
 					DockerContainers: &DockerContainersBundle{
 						RegistryAuths: []RegistryAuth{
-							{Server: "gcr.io", Username: "user", Password: "docker-secret"},
+							{Server: "gcr.io", Username: "user", Password: "$(docker_registry_password)"},
 						},
 					},
 				},
 			},
-			expected: []string{"docker-secret"},
+			expected: []string{"resolved-docker-secret"},
 		},
 		{
-			name: "podman containers registry secrets",
+			name: "podman containers registry secret resolved from parameter",
+			storeSecrets: []Parameter{
+				{Key: "podman_registry_password", Value: "resolved-podman-secret"},
+			},
 			config: CommittedConfig{
 				BundleData: BundleData{
 					PodmanContainers: &PodmanContainerBundle{
 						RegistryAuths: []RegistryAuth{
-							{Server: "gcr.io", Username: "user", Password: "podman-secret"},
+							{Server: "gcr.io", Username: "user", Password: "$(podman_registry_password)"},
 						},
 					},
 				},
 			},
-			expected: []string{"podman-secret"},
+			expected: []string{"resolved-podman-secret"},
 		},
 		{
-			name: "secrets from all bundles",
+			name: "secrets from all bundles sorted by length descending",
+			storeSecrets: []Parameter{
+				{Key: "docker_registry_password", Value: "docker-secret"},
+			},
 			config: CommittedConfig{
 				BundleData: BundleData{
 					Parameters: &ParametersBundle{
 						Secrets: []Parameter{
-							{Key: "db_password", Value: "param-secret"},
+							{Key: "db_password", Value: "parameters-registry-secret"},
 						},
 					},
 					DockerCompose: &DockerComposeBundle{
 						RegistryAuths: []RegistryAuth{
-							{Server: "gcr.io", Username: "user", Password: "compose-secret"},
+							{Server: "gcr.io", Username: "user", Password: "docker-compose-secret"},
 						},
 					},
 					DockerContainers: &DockerContainersBundle{
 						RegistryAuths: []RegistryAuth{
-							{Server: "gcr.io", Username: "user", Password: "docker-secret"},
+							{Server: "gcr.io", Username: "user", Password: "$(docker_registry_password)"},
 						},
 					},
 					PodmanContainers: &PodmanContainerBundle{
 						RegistryAuths: []RegistryAuth{
-							{Server: "gcr.io", Username: "user", Password: "podman-secret"},
+							{Server: "gcr.io", Username: "user", Password: "podman"},
 						},
 					},
 				},
 			},
-			expected: []string{"param-secret", "compose-secret", "docker-secret", "podman-secret"},
+			expected: []string{
+				"parameters-registry-secret",
+				"docker-compose-secret",
+				"docker-secret",
+				"podman",
+			},
+		},
+		{
+			name: "sorted by length descending to avoid false-prefix-matching",
+			config: CommittedConfig{
+				BundleData: BundleData{
+					Parameters: &ParametersBundle{
+						Secrets: []Parameter{
+							{Key: "short", Value: "password"},
+							{Key: "long", Value: "password123"},
+						},
+					},
+				},
+			},
+			expected: []string{"password123", "password"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.config.SecretsList(), tt.expected)
+			paramsBundle := &ParametersBundle{Secrets: tt.storeSecrets}
+			ctx := paramsBundle.Context(context.Background(), new(mockURLSigner))
+
+			assert.Equal(t, tt.config.SecretsList(ctx), tt.expected)
 		})
 	}
 }

--- a/app/configuration/service.go
+++ b/app/configuration/service.go
@@ -211,7 +211,7 @@ func (srv *Service) Execute(ctx context.Context, configData *CommittedConfig) er
 		srv.connectivityWatchdogThreshold = 0
 	}
 
-	reporter := NewReporter(configData.CommitID, srv.reportToConsole, parametersBundle.SecretsList())
+	reporter := NewReporter(configData.CommitID, srv.reportToConsole, configData.SecretsList())
 
 	for _, bundleName := range configData.Bundles {
 		log.Debugf("starting processing of bundle %s", bundleName)

--- a/app/configuration/service.go
+++ b/app/configuration/service.go
@@ -211,7 +211,7 @@ func (srv *Service) Execute(ctx context.Context, configData *CommittedConfig) er
 		srv.connectivityWatchdogThreshold = 0
 	}
 
-	reporter := NewReporter(configData.CommitID, srv.reportToConsole, configData.SecretsList())
+	reporter := NewReporter(configData.CommitID, srv.reportToConsole, configData.SecretsList(ctxWithParameters))
 
 	for _, bundleName := range configData.Bundles {
 		log.Debugf("starting processing of bundle %s", bundleName)


### PR DESCRIPTION
This pull request introduces a unified way to collect all secret values from different configuration bundles by adding a `SecretsList()` method to each bundle type and to the main `CommittedConfig` struct. This enables the system to consistently retrieve all secrets in one place, improving maintainability and reducing the risk of missing secrets when reporting or processing configurations. Additionally, the pull request updates the reporter initialization to use this unified secrets list and adds comprehensive unit tests for the new functionality.

**Secrets collection improvements:**

* Added a `SecretsList()` method to `CommittedConfig` that aggregates secrets from all bundle types (`Parameters`, `DockerCompose`, `DockerContainers`, `PodmanContainers`) for unified secret retrieval.
* Implemented `SecretsList()` methods for `DockerComposeBundle`, `DockerContainersBundle`, and `PodmanContainerBundle` to extract registry passwords as secrets. [[1]](diffhunk://#diff-c9192784c214022ccd4f399274b7193d6583fe0b46d3a9979a4d39dc936ab618R180-R192) [[2]](diffhunk://#diff-b6a576e3d752483bb2176237ef8f58d6c9c326ace5ce0fa89fb7fb64a4ae72fbR99-R111) [[3]](diffhunk://#diff-964f27b70af06dd44723692bc580e885709a7794f155696ee813338734d5925aR99-R111)

**Integration and testing:**

* Updated the `Service.Execute` method to use the new `CommittedConfig.SecretsList()` for initializing the reporter, ensuring all relevant secrets are included.
* Added a new test file, `config_test.go`, with thorough unit tests for `CommittedConfig.SecretsList()`, covering all bundle types and combinations.